### PR TITLE
Remove Contended annotation

### DIFF
--- a/src/main/java/com/ss/rlib/common/concurrent/lock/impl/AtomicLock.java
+++ b/src/main/java/com/ss/rlib/common/concurrent/lock/impl/AtomicLock.java
@@ -1,13 +1,12 @@
 package com.ss.rlib.common.concurrent.lock.impl;
 
-import com.ss.rlib.common.concurrent.atomic.AtomicInteger;
-import org.jetbrains.annotations.NotNull;
-
-import sun.misc.Contended;
-
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.ss.rlib.common.concurrent.atomic.AtomicInteger;
 
 /**
  * The implementation of the {@link Lock} based on using {@link AtomicInteger} without supporting
@@ -23,7 +22,6 @@ public class AtomicLock implements Lock {
     /**
      * The status of lock.
      */
-    @Contended
     protected final AtomicInteger status;
 
     /**

--- a/src/main/java/com/ss/rlib/common/concurrent/lock/impl/AtomicReadWriteLock.java
+++ b/src/main/java/com/ss/rlib/common/concurrent/lock/impl/AtomicReadWriteLock.java
@@ -1,13 +1,13 @@
 package com.ss.rlib.common.concurrent.lock.impl;
 
-import com.ss.rlib.common.concurrent.atomic.AtomicInteger;
-import com.ss.rlib.common.concurrent.lock.AsyncReadSyncWriteLock;
-import org.jetbrains.annotations.NotNull;
-import sun.misc.Contended;
-
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.ss.rlib.common.concurrent.atomic.AtomicInteger;
+import com.ss.rlib.common.concurrent.lock.AsyncReadSyncWriteLock;
 
 /**
  * The implementation of the {@link AsyncReadSyncWriteLock} using the several {@link AtomicInteger} without supporting
@@ -27,21 +27,18 @@ public class AtomicReadWriteLock implements AsyncReadSyncWriteLock, Lock {
      * The status of write lock.
      */
     @NotNull
-    @Contended("writeStatus")
     protected final AtomicInteger writeStatus;
 
     /**
      * The count of writers.
      */
     @NotNull
-    @Contended("writeCount")
     protected final AtomicInteger writeCount;
 
     /**
      * The count of readers.
      */
     @NotNull
-    @Contended("readCount")
     protected final AtomicInteger readCount;
 
     /**

--- a/src/main/java/com/ss/rlib/common/concurrent/lock/impl/ReentrantAtomicLock.java
+++ b/src/main/java/com/ss/rlib/common/concurrent/lock/impl/ReentrantAtomicLock.java
@@ -1,14 +1,13 @@
 package com.ss.rlib.common.concurrent.lock.impl;
 
-import com.ss.rlib.common.concurrent.atomic.AtomicReference;
-import com.ss.rlib.common.concurrent.atomic.AtomicInteger;
-import com.ss.rlib.common.concurrent.atomic.AtomicReference;
-import org.jetbrains.annotations.NotNull;
-import sun.misc.Contended;
-
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.ss.rlib.common.concurrent.atomic.AtomicInteger;
+import com.ss.rlib.common.concurrent.atomic.AtomicReference;
 
 /**
  * The implementation of the {@link Lock} based on using {@link AtomicInteger} with supporting
@@ -22,14 +21,12 @@ public class ReentrantAtomicLock implements Lock {
      * The status of lock.
      */
     @NotNull
-    @Contended("lock")
     private final AtomicReference<Thread> status;
 
     /**
      * The level of locking.
      */
     @NotNull
-    @Contended("level")
     private final AtomicInteger level;
 
     /**


### PR DESCRIPTION
Remove Contended annotation for avoid future problems with JVM compatibility (Contended - internal JVM annotation)