### PR TITLE
Extend API v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ repositories {
 }
 
 ext {
-   rlibVersion = "10.0.alpha7"
+   rlibVersion = "10.0.alpha8"
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-rootProject.version = "10.0.alpha7"
+rootProject.version = "10.0.alpha8"
 group = 'javasabr.rlib'
 
 allprojects {

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/IntArrayTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/IntArrayTest.java
@@ -2,7 +2,6 @@ package javasabr.rlib.collections.array;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/rlib-network/src/loadTest/java/javasabr/rlib/network/StringNetworkLoadTest.java
+++ b/rlib-network/src/loadTest/java/javasabr/rlib/network/StringNetworkLoadTest.java
@@ -67,7 +67,7 @@ public class StringNetworkLoadTest {
         ThreadUtils.sleep(random.nextInt(5000));
         StringDataConnection connection = network.connect(serverAddress);
 
-        connection.onReceive((serverConnection, packet) -> statistics
+        connection.onReceiveValidPacket((serverConnection, packet) -> statistics
             .receivedServerPackersPerSecond()
             .accumulate(1));
 
@@ -141,7 +141,7 @@ public class StringNetworkLoadTest {
     InetSocketAddress serverAddress = serverNetwork.start();
 
     serverNetwork.onAccept(accepted -> accepted
-        .onReceive((connection, packet) -> {
+        .onReceiveValidPacket((connection, packet) -> {
           StringReadableNetworkPacket<StringDataConnection> receivedPacket = (StringReadableNetworkPacket<StringDataConnection>) packet;
           statistics
               .receivedClientPackersPerSecond()

--- a/rlib-network/src/loadTest/java/javasabr/rlib/network/StringNetworkLoadTest.java
+++ b/rlib-network/src/loadTest/java/javasabr/rlib/network/StringNetworkLoadTest.java
@@ -41,7 +41,7 @@ public class StringNetworkLoadTest {
 
     String clientId = "Client_%s".formatted(ID_FACTORY.incrementAndGet());
     NetworkConfig networkConfig = NetworkConfig.SimpleNetworkConfig.builder()
-        .groupName(clientId)
+        .threadGroupName(clientId)
         .writeBufferSize(256)
         .readBufferSize(256)
         .pendingBufferSize(512)

--- a/rlib-network/src/loadTest/java/javasabr/rlib/network/StringSslNetworkLoadTest.java
+++ b/rlib-network/src/loadTest/java/javasabr/rlib/network/StringSslNetworkLoadTest.java
@@ -44,7 +44,7 @@ public class StringSslNetworkLoadTest {
 
     String clientId = "Client_%s".formatted(ID_FACTORY.incrementAndGet());
     NetworkConfig networkConfig = NetworkConfig.SimpleNetworkConfig.builder()
-        .groupName(clientId)
+        .threadGroupName(clientId)
         .writeBufferSize(256)
         .readBufferSize(256)
         .pendingBufferSize(512)

--- a/rlib-network/src/loadTest/java/javasabr/rlib/network/StringSslNetworkLoadTest.java
+++ b/rlib-network/src/loadTest/java/javasabr/rlib/network/StringSslNetworkLoadTest.java
@@ -70,7 +70,7 @@ public class StringSslNetworkLoadTest {
         ThreadUtils.sleep(random.nextInt(5000));
         StringDataSslConnection connection = network.connect(serverAddress);
 
-        connection.onReceive((serverConnection, packet) -> statistics
+        connection.onReceiveValidPacket((serverConnection, packet) -> statistics
             .receivedServerPackersPerSecond()
             .accumulate(1));
 
@@ -150,7 +150,7 @@ public class StringSslNetworkLoadTest {
     InetSocketAddress serverAddress = serverNetwork.start();
 
     serverNetwork.onAccept(accepted -> accepted
-        .onReceive((connection, packet) -> {
+        .onReceiveValidPacket((connection, packet) -> {
           StringReadableNetworkPacket<StringDataSslConnection> receivedPacket = (StringReadableNetworkPacket<StringDataSslConnection>) packet;
           statistics
               .receivedClientPackersPerSecond()

--- a/rlib-network/src/main/java/javasabr/rlib/network/Network.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/Network.java
@@ -13,6 +13,8 @@ public interface Network<C extends Connection<C>> {
 
   NetworkConfig config();
 
+  void inNetworkThread(Runnable task);
+
   /**
    * Shutdown this network.
    */

--- a/rlib-network/src/main/java/javasabr/rlib/network/NetworkConfig.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/NetworkConfig.java
@@ -1,6 +1,7 @@
 package javasabr.rlib.network;
 
 import java.nio.ByteOrder;
+import javasabr.rlib.common.util.GroupThreadFactory.ThreadConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -18,9 +19,13 @@ public interface NetworkConfig {
   class SimpleNetworkConfig implements NetworkConfig {
 
     @Builder.Default
-    private String groupName = "NetworkThread";
+    private String threadGroupName = "NetworkThread";
     @Builder.Default
     private ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
+    @Builder.Default
+    private ThreadConstructor threadConstructor = Thread::new;
+    @Builder.Default
+    private int threadPriority = Thread.NORM_PRIORITY;
 
     @Builder.Default
     private int readBufferSize = 2048;
@@ -45,6 +50,22 @@ public interface NetworkConfig {
       return "ClientNetworkThread";
     }
   };
+
+  /**
+   * Get a thread constructor which should be used to create network threads.
+   */
+  default ThreadConstructor threadConstructor() {
+    return Thread::new;
+  }
+
+  /**
+   * Get a priority of network threads.
+   *
+   * @return the priority of network threads.
+   */
+  default int threadPriority() {
+    return Thread.NORM_PRIORITY;
+  }
 
   /**
    * Get a group name of network threads.

--- a/rlib-network/src/main/java/javasabr/rlib/network/ServerNetworkConfig.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/ServerNetworkConfig.java
@@ -82,21 +82,4 @@ public interface ServerNetworkConfig extends NetworkConfig {
   default int scheduledThreadGroupSize() {
     return 1;
   }
-
-
-  /**
-   * Get a thread constructor which should be used to create network threads.
-   */
-  default ThreadConstructor threadConstructor() {
-    return Thread::new;
-  }
-
-  /**
-   * Get a priority of network threads.
-   *
-   * @return the priority of network threads.
-   */
-  default int threadPriority() {
-    return Thread.NORM_PRIORITY;
-  }
 }

--- a/rlib-network/src/main/java/javasabr/rlib/network/exception/MalformedProtocolException.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/exception/MalformedProtocolException.java
@@ -1,6 +1,6 @@
 package javasabr.rlib.network.exception;
 
-public class MalformedProtocolException extends RuntimeException {
+public class MalformedProtocolException extends NetworkException {
   public MalformedProtocolException(String message) {
     super(message);
   }

--- a/rlib-network/src/main/java/javasabr/rlib/network/exception/NetworkException.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/exception/NetworkException.java
@@ -1,0 +1,16 @@
+package javasabr.rlib.network.exception;
+
+public class NetworkException extends RuntimeException {
+
+  protected NetworkException(String message) {
+    super(message);
+  }
+
+  protected NetworkException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  protected NetworkException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/rlib-network/src/main/java/javasabr/rlib/network/exception/UserDefinedNetworkException.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/exception/UserDefinedNetworkException.java
@@ -1,0 +1,15 @@
+package javasabr.rlib.network.exception;
+
+public class UserDefinedNetworkException extends NetworkException {
+  protected UserDefinedNetworkException(String message) {
+    super(message);
+  }
+
+  protected UserDefinedNetworkException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  protected UserDefinedNetworkException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/rlib-network/src/main/java/javasabr/rlib/network/impl/AbstractConnection.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/impl/AbstractConnection.java
@@ -62,7 +62,8 @@ public abstract class AbstractConnection<C extends AbstractConnection<C>> implem
   final StampedLock lock;
   final AtomicBoolean closed;
 
-  final MutableArray<BiConsumer<C, ? super ReadableNetworkPacket<C>>> subscribers;
+  final MutableArray<BiConsumer<C, ? super ReadableNetworkPacket<C>>> validPacketSubscribers;
+  final MutableArray<BiConsumer<C, ? super ReadableNetworkPacket<C>>> invalidPacketSubscribers;
 
   final int maxPacketsByRead;
 
@@ -81,7 +82,8 @@ public abstract class AbstractConnection<C extends AbstractConnection<C>> implem
     this.pendingPackets = DequeFactory.arrayBasedBased(WritableNetworkPacket.class);
     this.network = network;
     this.closed = new AtomicBoolean(false);
-    this.subscribers = ArrayFactory.copyOnModifyArray(BiConsumer.class);
+    this.validPacketSubscribers = ArrayFactory.copyOnModifyArray(BiConsumer.class);
+    this.invalidPacketSubscribers = ArrayFactory.copyOnModifyArray(BiConsumer.class);
     this.remoteAddress = String.valueOf(NetworkUtils.getRemoteAddress(channel));
   }
 
@@ -93,8 +95,14 @@ public abstract class AbstractConnection<C extends AbstractConnection<C>> implem
   protected abstract NetworkPacketWriter packetWriter();
 
   @Override
-  public void onReceive(BiConsumer<C, ? super ReadableNetworkPacket<C>> consumer) {
-    subscribers.add(consumer);
+  public void onReceiveValidPacket(BiConsumer<C, ? super ReadableNetworkPacket<C>> consumer) {
+    validPacketSubscribers.add(consumer);
+    packetReader().startRead();
+  }
+
+  @Override
+  public void onReceiveInvalidPacket(BiConsumer<C, ? super ReadableNetworkPacket<C>> consumer) {
+    invalidPacketSubscribers.add(consumer);
     packetReader().startRead();
   }
 
@@ -104,26 +112,43 @@ public abstract class AbstractConnection<C extends AbstractConnection<C>> implem
   }
 
   @Override
-  public Flux<? extends ReadableNetworkPacket<C>> receivedPackets() {
-    return Flux.create(this::registerFluxOnReceivedPackets);
+  public Flux<? extends ReadableNetworkPacket<C>> receivedValidPackets() {
+    return Flux.create(this::registerFluxOnReceivedValidPackets);
+  }
+
+  @Override
+  public Flux<? extends ReadableNetworkPacket<C>> receivedInvalidPackets() {
+    return Flux.create(this::registerFluxOnReceivedInvalidPackets);
   }
 
   protected void registerFluxOnReceivedEvents(
       FluxSink<ReceivedPacketEvent<C, ? extends ReadableNetworkPacket<C>>> sink) {
 
-    BiConsumer<C, ReadableNetworkPacket<C>> listener =
+    BiConsumer<C, ReadableNetworkPacket<C>> validListener =
       (connection, packet) -> sink.next(new ReceivedPacketEvent<>(connection,
-        packet));
+        packet, true));
+    BiConsumer<C, ReadableNetworkPacket<C>> invalidListener =
+        (connection, packet) -> sink.next(new ReceivedPacketEvent<>(connection,
+            packet, true));
 
-    onReceive(listener);
 
-    sink.onDispose(() -> subscribers.remove(listener));
+    onReceiveValidPacket(validListener);
+    onReceiveInvalidPacket(invalidListener);
+
+    sink.onDispose(() -> validPacketSubscribers.remove(validListener));
+    sink.onDispose(() -> invalidPacketSubscribers.remove(invalidListener));
   }
 
-  protected void registerFluxOnReceivedPackets(FluxSink<? super ReadableNetworkPacket<C>> sink) {
+  protected void registerFluxOnReceivedValidPackets(FluxSink<? super ReadableNetworkPacket<C>> sink) {
     BiConsumer<C, ReadableNetworkPacket<C>> listener = (connection, packet) -> sink.next(packet);
-    onReceive(listener);
-    sink.onDispose(() -> subscribers.remove(listener));
+    onReceiveValidPacket(listener);
+    sink.onDispose(() -> validPacketSubscribers.remove(listener));
+  }
+
+  protected void registerFluxOnReceivedInvalidPackets(FluxSink<? super ReadableNetworkPacket<C>> sink) {
+    BiConsumer<C, ReadableNetworkPacket<C>> listener = (connection, packet) -> sink.next(packet);
+    onReceiveInvalidPacket(listener);
+    sink.onDispose(() -> invalidPacketSubscribers.remove(listener));
   }
 
   @Nullable
@@ -169,9 +194,16 @@ public abstract class AbstractConnection<C extends AbstractConnection<C>> implem
 
   protected void serializedPacket(WritableNetworkPacket<?> packet) {}
 
-  protected void handleReceivedPacket(ReadableNetworkPacket<C> packet) {
-    log.debug(packet, remoteAddress, "Handle received packet:[%s] from:[%s]"::formatted);
-    subscribers
+  protected void handleReceivedValidPacket(ReadableNetworkPacket<C> packet) {
+    log.debug(packet, remoteAddress, "Handle received valid packet:[%s] from:[%s]"::formatted);
+    validPacketSubscribers
+        .iterations()
+        .forEach((C) this, packet, BiConsumer::accept);
+  }
+
+  protected void handleReceivedInvalidPacket(ReadableNetworkPacket<C> packet) {
+    log.debug(packet, remoteAddress, "Handle failed received packet:[%s] from:[%s]"::formatted);
+    invalidPacketSubscribers
         .iterations()
         .forEach((C) this, packet, BiConsumer::accept);
   }

--- a/rlib-network/src/main/java/javasabr/rlib/network/impl/DefaultDataConnection.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/impl/DefaultDataConnection.java
@@ -44,7 +44,8 @@ public abstract class DefaultDataConnection<C extends DefaultDataConnection<C>>
     return new DefaultNetworkPacketReader<>(
         (C) this,
         this::updateLastActivity,
-        this::handleReceivedPacket,
+        this::handleReceivedValidPacket,
+        this::handleReceivedInvalidPacket,
         value -> createReadablePacket(),
         packetLengthHeaderSize,
         maxPacketsByRead);

--- a/rlib-network/src/main/java/javasabr/rlib/network/impl/DefaultDataSslConnection.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/impl/DefaultDataSslConnection.java
@@ -45,7 +45,8 @@ public abstract class DefaultDataSslConnection<C extends DefaultDataSslConnectio
     return new DefaultSslNetworkPacketReader<>(
         (C) this,
         this::updateLastActivity,
-        this::handleReceivedPacket,
+        this::handleReceivedValidPacket,
+        this::handleReceivedInvalidPacket,
         value -> createReadablePacket(),
         sslEngine,
         this::sendImpl,

--- a/rlib-network/src/main/java/javasabr/rlib/network/impl/IdBasedPacketConnection.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/impl/IdBasedPacketConnection.java
@@ -50,7 +50,8 @@ public class IdBasedPacketConnection<C extends IdBasedPacketConnection<C>> exten
     return new IdBasedNetworkPacketReader<>(
         (C) this,
         this::updateLastActivity,
-        this::handleReceivedPacket,
+        this::handleReceivedValidPacket,
+        this::handleReceivedInvalidPacket,
         packetLengthHeaderSize,
         maxPacketsByRead,
         packetIdHeaderSize,

--- a/rlib-network/src/main/java/javasabr/rlib/network/packet/impl/AbstractSslNetworkPacketReader.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/packet/impl/AbstractSslNetworkPacketReader.java
@@ -50,11 +50,12 @@ public abstract class AbstractSslNetworkPacketReader<
   protected AbstractSslNetworkPacketReader(
       C connection,
       Runnable updateActivityFunction,
-      Consumer<? super R> readPacketHandler,
+      Consumer<? super R> validPacketHandler,
+      Consumer<? super R> invalidPacketHandler,
       SSLEngine sslEngine,
       Consumer<WritableNetworkPacket<C>> packetWriter,
       int maxPacketsByRead) {
-    super(connection, updateActivityFunction, readPacketHandler, maxPacketsByRead);
+    super(connection, updateActivityFunction, validPacketHandler, invalidPacketHandler, maxPacketsByRead);
     BufferAllocator bufferAllocator = connection.bufferAllocator();
     this.sslEngine = sslEngine;
     this.sslDataBuffer = bufferAllocator.takeBuffer(sslEngine

--- a/rlib-network/src/main/java/javasabr/rlib/network/packet/impl/DefaultNetworkPacketReader.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/packet/impl/DefaultNetworkPacketReader.java
@@ -23,11 +23,12 @@ public class DefaultNetworkPacketReader<
   public DefaultNetworkPacketReader(
       C connection,
       Runnable updateActivityFunction,
-      Consumer<R> packetHandler,
+      Consumer<? super R> validPacketHandler,
+      Consumer<? super R> invalidPacketHandler,
       IntFunction<R> readablePacketFactory,
       int packetLengthHeaderSize,
       int maxPacketsByRead) {
-    super(connection, updateActivityFunction, packetHandler, maxPacketsByRead);
+    super(connection, updateActivityFunction, validPacketHandler, invalidPacketHandler, maxPacketsByRead);
     this.readablePacketFactory = readablePacketFactory;
     this.packetLengthHeaderSize = packetLengthHeaderSize;
   }

--- a/rlib-network/src/main/java/javasabr/rlib/network/packet/impl/DefaultSslNetworkPacketReader.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/packet/impl/DefaultSslNetworkPacketReader.java
@@ -25,7 +25,8 @@ public class DefaultSslNetworkPacketReader<
   public DefaultSslNetworkPacketReader(
       C connection,
       Runnable updateActivityFunction,
-      Consumer<R> packetHandler,
+      Consumer<? super R> validPacketHandler,
+      Consumer<? super R> invalidPacketHandler,
       IntFunction<R> packetResolver,
       SSLEngine sslEngine,
       Consumer<WritableNetworkPacket<C>> packetWriter,
@@ -34,7 +35,8 @@ public class DefaultSslNetworkPacketReader<
     super(
         connection,
         updateActivityFunction,
-        packetHandler,
+        validPacketHandler,
+        invalidPacketHandler,
         sslEngine,
         packetWriter,
         maxPacketsByRead);

--- a/rlib-network/src/main/java/javasabr/rlib/network/packet/impl/IdBasedNetworkPacketReader.java
+++ b/rlib-network/src/main/java/javasabr/rlib/network/packet/impl/IdBasedNetworkPacketReader.java
@@ -24,12 +24,13 @@ public class IdBasedNetworkPacketReader<
   public IdBasedNetworkPacketReader(
       C connection,
       Runnable updateActivityFunction,
-      Consumer<R> packetHandler,
+      Consumer<? super R> validPacketHandler,
+      Consumer<? super R> invalidPacketHandler,
       int packetLengthHeaderSize,
       int maxPacketsByRead,
       int packetIdHeaderSize,
       ReadableNetworkPacketRegistry<R, C> packetRegistry) {
-    super(connection, updateActivityFunction, packetHandler, maxPacketsByRead);
+    super(connection, updateActivityFunction, validPacketHandler, invalidPacketHandler, maxPacketsByRead);
     this.packetLengthHeaderSize = packetLengthHeaderSize;
     this.packetIdHeaderSize = packetIdHeaderSize;
     this.packetRegistry = packetRegistry;

--- a/rlib-network/src/test/java/javasabr/rlib/network/BaseNetworkTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/BaseNetworkTest.java
@@ -59,12 +59,20 @@ public class BaseNetworkTest {
     }
 
     @Override
-    public Flux receivedPackets() {
+    public Flux<? extends ReadableNetworkPacket<MockConnection>> receivedValidPackets() {
       return Flux.empty();
     }
 
     @Override
-    public void onReceive(BiConsumer consumer) {}
+    public Flux<? extends ReadableNetworkPacket<MockConnection>> receivedInvalidPackets() {
+      return Flux.empty();
+    }
+
+    @Override
+    public void onReceiveValidPacket(BiConsumer<MockConnection, ? super ReadableNetworkPacket<MockConnection>> consumer) {}
+
+    @Override
+    public void onReceiveInvalidPacket(BiConsumer<MockConnection, ? super ReadableNetworkPacket<MockConnection>> consumer) {}
   }
 
   public static final MockConnection MOCK_CONNECTION = new MockConnection();

--- a/rlib-network/src/test/java/javasabr/rlib/network/DefaultNetworkTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/DefaultNetworkTest.java
@@ -263,7 +263,7 @@ public class DefaultNetworkTest extends BaseNetworkTest {
       DefaultConnection serverToClient = testNetwork.serverToClient;
 
       var pendingPacketsOnServer = serverToClient
-          .receivedPackets()
+          .receivedValidPackets()
           .buffer(packetCount);
 
       List<String> messages = IntStream

--- a/rlib-network/src/test/java/javasabr/rlib/network/HandlingValidAndInvalidReceivedPacketsTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/HandlingValidAndInvalidReceivedPacketsTest.java
@@ -1,0 +1,127 @@
+package javasabr.rlib.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import javasabr.rlib.logger.api.LoggerLevel;
+import javasabr.rlib.logger.api.LoggerManager;
+import javasabr.rlib.network.annotation.NetworkPacketDescription;
+import javasabr.rlib.network.impl.DefaultConnection;
+import javasabr.rlib.network.packet.impl.DefaultReadableNetworkPacket;
+import javasabr.rlib.network.packet.impl.DefaultWritableNetworkPacket;
+import javasabr.rlib.network.packet.registry.ReadableNetworkPacketRegistry;
+import javasabr.rlib.network.server.ServerNetwork;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@CustomLog
+public class HandlingValidAndInvalidReceivedPacketsTest extends BaseNetworkTest {
+
+  static {
+    LoggerManager.enable(HandlingValidAndInvalidReceivedPacketsTest.class, LoggerLevel.INFO);
+    //LoggerManager.enable(AbstractConnection.class, LoggerLevel.DEBUG);
+  }
+
+  // client packets
+  interface ClientPackets {
+
+    @RequiredArgsConstructor
+    @NetworkPacketDescription(id = 1)
+    class TestValidatablePacket extends DefaultWritableNetworkPacket<DefaultConnection> {
+
+      private final boolean valid;
+
+      @Override
+      protected void writeImpl(DefaultConnection connection, ByteBuffer buffer) {
+        super.writeImpl(connection, buffer);
+        writeByte(buffer, valid ? 1 : 0);
+      }
+    }
+
+    @NetworkPacketDescription(id = 2)
+    class MockReadablePacket extends DefaultReadableNetworkPacket<DefaultConnection> {}
+  }
+
+  // server packets
+  interface ServerPackets {
+
+    @NetworkPacketDescription(id = 1)
+    class TestValidatablePacket extends DefaultReadableNetworkPacket<DefaultConnection> {
+
+      @Override
+      protected void readImpl(DefaultConnection connection, ByteBuffer buffer) {
+        super.readImpl(connection, buffer);
+        if (readByte(buffer) == 0) {
+          throw new RuntimeException("Received invalid packet");
+        }
+      }
+    }
+  }
+
+  @Test
+  void shouldCorrectlyReceiveValidAndInvalidPackets() throws InterruptedException {
+    // given:
+    ReadableNetworkPacketRegistry<DefaultReadableNetworkPacket<DefaultConnection>, DefaultConnection> serverPackets =
+        ReadableNetworkPacketRegistry.of(DefaultReadableNetworkPacket.class, DefaultConnection.class, ServerPackets.TestValidatablePacket.class);
+    ReadableNetworkPacketRegistry<DefaultReadableNetworkPacket<DefaultConnection>, DefaultConnection> clientPackets =
+        ReadableNetworkPacketRegistry.of(DefaultReadableNetworkPacket.class, DefaultConnection.class, ClientPackets.MockReadablePacket.class);
+
+    ServerNetwork<DefaultConnection> serverNetwork = NetworkFactory.defaultServerNetwork(serverPackets);
+    InetSocketAddress serverAddress = serverNetwork.start();
+    List<ServerPackets.TestValidatablePacket> receivedValidPackets = Collections
+        .synchronizedList(new ArrayList<>());
+    List<ServerPackets.TestValidatablePacket> receivedInvalidPackets = Collections
+        .synchronizedList(new ArrayList<>());
+
+    var counter = new CountDownLatch(30);
+
+    // when:
+    serverNetwork
+        .accepted()
+        .flatMap(connection -> connection.receivedEvents(ServerPackets.TestValidatablePacket.class))
+        .doOnNext(event -> {
+          var packet = event.packet();
+          if (event.valid()) {
+            receivedValidPackets.add(packet);
+          } else {
+            receivedInvalidPackets.add(packet);
+          }
+          counter.countDown();
+        })
+        .subscribe(event -> log.info(event, "Received from client:[%s]"::formatted));
+
+    var clientNetwork = NetworkFactory.defaultClientNetwork(clientPackets);
+    clientNetwork
+        .connectReactive(serverAddress)
+        .doOnNext(connection -> IntStream
+            .range(0, 30)
+            .forEach(length -> {
+              if (length % 5 == 0) {
+                connection.send(new ClientPackets.TestValidatablePacket(false));
+              } else {
+                connection.send(new ClientPackets.TestValidatablePacket(true));
+              }
+            }))
+        .subscribe();
+
+    Assertions.assertTrue(
+        counter.await(10000, TimeUnit.MILLISECONDS),
+        "Still wait for " + counter.getCount() + " packets...");
+
+    clientNetwork.shutdown();
+    serverNetwork.shutdown();
+
+    // then:
+    assertThat(receivedInvalidPackets).hasSize(6);
+    assertThat(receivedValidPackets).hasSize(24);
+  }
+}

--- a/rlib-network/src/test/java/javasabr/rlib/network/StringNetworkTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/StringNetworkTest.java
@@ -119,7 +119,7 @@ public class StringNetworkTest extends BaseNetworkTest {
       StringDataConnection serverToClient = testNetwork.serverToClient;
 
       var pendingPacketsOnServer = serverToClient
-          .receivedPackets(RECEIVED_PACKET_TYPE)
+          .receivedValidPackets(RECEIVED_PACKET_TYPE)
           .buffer(packetCount);
 
       List<String> messages = IntStream
@@ -165,7 +165,7 @@ public class StringNetworkTest extends BaseNetworkTest {
       StringDataConnection serverToClient = testNetwork.serverToClient;
 
       var pendingPacketsOnServer = serverToClient
-          .receivedPackets(RECEIVED_PACKET_TYPE)
+          .receivedValidPackets(RECEIVED_PACKET_TYPE)
           .doOnNext(packet ->
               log.info(packet.data().length(), "Received [%s] symbols from client"::formatted))
           .buffer(packetCount);
@@ -223,7 +223,7 @@ public class StringNetworkTest extends BaseNetworkTest {
       StringDataConnection serverToClient = testNetwork.serverToClient;
 
       var pendingPacketsOnServer = serverToClient
-          .receivedPackets(RECEIVED_PACKET_TYPE)
+          .receivedValidPackets(RECEIVED_PACKET_TYPE)
           .doOnNext(packet ->
               log.info(packet.data().length(), "Received [%s] symbols from client"::formatted))
           .buffer(packetCount);
@@ -352,7 +352,7 @@ public class StringNetworkTest extends BaseNetworkTest {
     var connectedClients = new CountDownLatch(clientCount);
 
     serverNetwork.onAccept(connection -> {
-      connection.onReceive((con, packet) -> {
+      connection.onReceiveValidPacket((con, packet) -> {
         receivedPacketsOnServer.incrementAndGet();
         con.send(newMessage(minMessageLength, maxMessageLength));
       });
@@ -371,7 +371,7 @@ public class StringNetworkTest extends BaseNetworkTest {
         .stream()
         .map(ClientNetwork::currentConnection)
         .filter(Objects::nonNull)
-        .peek(connection -> connection.onReceive((con, packet) -> {
+        .peek(connection -> connection.onReceiveValidPacket((con, packet) -> {
           receivedPacketsOnClients.incrementAndGet();
           counter.countDown();
         }))
@@ -403,7 +403,7 @@ public class StringNetworkTest extends BaseNetworkTest {
       StringDataConnection serverToClient = testNetwork.serverToClient;
 
       var pendingPacketsOnServer = serverToClient
-          .receivedPackets()
+          .receivedValidPackets()
           .buffer(packetCount);
 
       List<CompletableFuture<Boolean>> asyncResults = IntStream

--- a/rlib-network/src/test/java/javasabr/rlib/network/StringSslNetworkTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/StringSslNetworkTest.java
@@ -293,7 +293,7 @@ public class StringSslNetworkTest extends BaseNetworkTest {
       StringDataSslConnection serverToClient = testNetwork.serverToClient;
 
       var pendingPacketsOnServer = serverToClient
-          .receivedPackets()
+          .receivedValidPackets()
           .doOnNext(packet -> log.info("Received from client: " + packet))
           .buffer(packetCount);
 


### PR DESCRIPTION
Extend Network API:
1. Add API to handle received invalid network packets
2. Add API to execute tasks in network threads
3. Initialize acception connections and reading packets from network thread always.