### PR TITLE
Extend API v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ repositories {
 }
 
 ext {
-    rlibVersion = "10.0.alpha10"
+    rlibVersion = "10.0.alpha11"
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-rootProject.version = "10.0.alpha10"
+rootProject.version = "10.0.alpha11"
 group = 'javasabr.rlib'
 
 allprojects {

--- a/rlib-classpath/src/test/java/javasabr/rlib/classpath/ClasspathScannerTests.java
+++ b/rlib-classpath/src/test/java/javasabr/rlib/classpath/ClasspathScannerTests.java
@@ -1,11 +1,12 @@
 package javasabr.rlib.classpath;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collection;
 import javasabr.rlib.collections.array.Array;
 import javasabr.rlib.collections.array.impl.AbstractArray;
 import javasabr.rlib.logger.api.LoggerLevel;
 import javasabr.rlib.logger.api.LoggerManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,10 +27,10 @@ public class ClasspathScannerTests {
 
     Array<Class<Collection>> implementations = scanner.findImplementations(Collection.class);
 
-    Assertions.assertFalse(implementations.isEmpty());
+    assertThat(implementations.isEmpty()).isFalse();
 
     Array<Class<AbstractArray>> inherited = scanner.findInherited(AbstractArray.class);
 
-    Assertions.assertFalse(inherited.isEmpty());
+    assertThat(inherited.isEmpty()).isFalse();
   }
 }

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/array/impl/AbstractMutableArray.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/array/impl/AbstractMutableArray.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javasabr.rlib.collections.array.Array;
 import javasabr.rlib.collections.array.UnsafeMutableArray;
-import javasabr.rlib.common.util.ObjectUtils;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import org.jspecify.annotations.Nullable;

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableIntToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableIntToRefDictionary.java
@@ -25,6 +25,12 @@ public interface MutableIntToRefDictionary<V> extends IntToRefDictionary<V> {
   @Nullable
   V put(int key, V value);
 
+  /**
+   * @return the previous value associated with the specified key, or null if there was no mapping for the key.
+   */
+  @Nullable
+  V putIfAbsent(int key, V value);
+  
   void putAll(IntToRefDictionary<? extends V> dictionary);
 
   MutableIntToRefDictionary<V> append(IntToRefDictionary<? extends V> dictionary);
@@ -40,6 +46,11 @@ public interface MutableIntToRefDictionary<V> extends IntToRefDictionary<V> {
   @Nullable
   V remove(int key);
 
+  /**
+   * @return true if the expectedValue was removed
+   */
+  boolean remove(int key, V expectedValue);
+  
   /**
    * @return the optional value of the previous value for the key.
    */

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableIntToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableIntToRefDictionary.java
@@ -26,7 +26,7 @@ public interface MutableIntToRefDictionary<V> extends IntToRefDictionary<V> {
   V put(int key, V value);
 
   /**
-   * @return the previous value associated with the specified key, or null if there was no mapping for the key.
+   * @return the existing value if the key is already present, or null if the key was absent and the new mapping was added.
    */
   @Nullable
   V putIfAbsent(int key, V value);

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableLongToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableLongToRefDictionary.java
@@ -26,7 +26,7 @@ public interface MutableLongToRefDictionary<V> extends LongToRefDictionary<V> {
   V put(long key, V value);
 
   /**
-   * @return the previous value associated with the specified key, or null if there was no mapping for the key.
+   * @return the existing value if the key is already present, or null if the key was absent and the new mapping was added.
    */
   @Nullable
   V putIfAbsent(long key, V value);

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableLongToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableLongToRefDictionary.java
@@ -25,6 +25,12 @@ public interface MutableLongToRefDictionary<V> extends LongToRefDictionary<V> {
   @Nullable
   V put(long key, V value);
 
+  /**
+   * @return the previous value associated with the specified key, or null if there was no mapping for the key.
+   */
+  @Nullable
+  V putIfAbsent(long key, V value);
+  
   void putAll(LongToRefDictionary<? extends V> dictionary);
 
   MutableLongToRefDictionary<V> append(LongToRefDictionary<? extends V> dictionary);
@@ -40,6 +46,11 @@ public interface MutableLongToRefDictionary<V> extends LongToRefDictionary<V> {
   @Nullable
   V remove(long key);
 
+  /**
+   * @return true if the expectedValue was removed
+   */
+  boolean remove(long key, V expectedValue);
+  
   /**
    * @return the optional value of the previous value for the key.
    */

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionary.java
@@ -26,6 +26,12 @@ public interface MutableRefToRefDictionary<K, V> extends RefToRefDictionary<K, V
   @Nullable
   V put(K key, V value);
 
+  /**
+   * @return the previous value associated with the specified key, or null if there was no mapping for the key.
+   */
+  @Nullable 
+  V putIfAbsent(K key, V value);
+  
   void putAll(RefToRefDictionary<? extends K, ? extends V> dictionary);
 
   MutableRefToRefDictionary<K, V> append(RefToRefDictionary<? extends K, ? extends V> dictionary);
@@ -41,6 +47,11 @@ public interface MutableRefToRefDictionary<K, V> extends RefToRefDictionary<K, V
   @Nullable
   V remove(K key);
 
+  /**
+   * @return true if the expectedValue was removed
+   */
+  boolean remove(K key, V expectedValue);
+  
   /**
    * @return the optional value of the previous value for the key.
    */

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionary.java
@@ -27,7 +27,7 @@ public interface MutableRefToRefDictionary<K, V> extends RefToRefDictionary<K, V
   V put(K key, V value);
 
   /**
-   * @return the previous value associated with the specified key, or null if there was no mapping for the key.
+   * @return the existing value if the key is already present, or null if the key was absent and the new mapping was added.
    */
   @Nullable 
   V putIfAbsent(K key, V value);

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedIntToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedIntToRefDictionary.java
@@ -94,7 +94,7 @@ public abstract class AbstractMutableHashBasedIntToRefDictionary<V, E extends Li
 
     for (E entry = entries[entryIndex]; entry != null; entry = entry.next()) {
       if (entry.hash() == hash && key == entry.key()) {
-        return null;
+        return entry.value();
       }
     }
 
@@ -144,25 +144,25 @@ public abstract class AbstractMutableHashBasedIntToRefDictionary<V, E extends Li
     int hash = hash(key);
     int entryIndex = indexFor(hash, entries.length);
 
-    E previosEntry = entries[entryIndex];
-    E entry = previosEntry;
+    E previousEntry = entries[entryIndex];
+    E entry = previousEntry;
 
     while (entry != null) {
       E nextEntry = entry.next();
       if (entry.hash() == hash && key == entry.key()) {
         if (Objects.equals(entry.value(), expectedValue)) {
           decrementSize();
-          if (previosEntry == entry) {
+          if (previousEntry == entry) {
             entries[entryIndex] = nextEntry;
           } else {
-            previosEntry.next(nextEntry);
+            previousEntry.next(nextEntry);
           }
           return true;
         } else {
           return false;
         }
       }
-      previosEntry = entry;
+      previousEntry = entry;
       entry = nextEntry;
     }
 

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedIntToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedIntToRefDictionary.java
@@ -1,5 +1,6 @@
 package javasabr.rlib.collections.dictionary.impl;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -84,6 +85,23 @@ public abstract class AbstractMutableHashBasedIntToRefDictionary<V, E extends Li
     return null;
   }
 
+  @Nullable
+  @Override
+  public V putIfAbsent(int key, V value) {
+    @Nullable E[] entries = entries();
+    int hash = hash(key);
+    int entryIndex = indexFor(hash, entries.length);
+
+    for (E entry = entries[entryIndex]; entry != null; entry = entry.next()) {
+      if (entry.hash() == hash && key == entry.key()) {
+        return null;
+      }
+    }
+
+    addEntry(hash, key, value, entryIndex);
+    return null;
+  }
+  
   @Override
   public Optional<V> putOptional(int key, V value) {
     return Optional.ofNullable(put(key, value));
@@ -118,6 +136,37 @@ public abstract class AbstractMutableHashBasedIntToRefDictionary<V, E extends Li
       return null;
     }
     return removed.value();
+  }
+
+  @Override
+  public boolean remove(int key, V expectedValue) {
+    @Nullable E[] entries = entries();
+    int hash = hash(key);
+    int entryIndex = indexFor(hash, entries.length);
+
+    E previosEntry = entries[entryIndex];
+    E entry = previosEntry;
+
+    while (entry != null) {
+      E nextEntry = entry.next();
+      if (entry.hash() == hash && key == entry.key()) {
+        if (Objects.equals(entry.value(), expectedValue)) {
+          decrementSize();
+          if (previosEntry == entry) {
+            entries[entryIndex] = nextEntry;
+          } else {
+            previosEntry.next(nextEntry);
+          }
+          return true;
+        } else {
+          return false;
+        }
+      }
+      previosEntry = entry;
+      entry = nextEntry;
+    }
+
+    return false;
   }
 
   @Override

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedLongToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedLongToRefDictionary.java
@@ -1,5 +1,6 @@
 package javasabr.rlib.collections.dictionary.impl;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.LongFunction;
@@ -83,7 +84,24 @@ public abstract class AbstractMutableHashBasedLongToRefDictionary<V, E extends L
     addEntry(hash, key, value, entryIndex);
     return null;
   }
+  
+  @Nullable
+  @Override
+  public V putIfAbsent(long key, V value) {
+    @Nullable E[] entries = entries();
+    int hash = hash(Long.hashCode(key));
+    int entryIndex = indexFor(hash, entries.length);
 
+    for (E entry = entries[entryIndex]; entry != null; entry = entry.next()) {
+      if (entry.hash() == hash && key == entry.key()) {
+        return null;
+      }
+    }
+
+    addEntry(hash, key, value, entryIndex);
+    return null;
+  }
+  
   @Override
   public Optional<V> putOptional(long key, V value) {
     return Optional.ofNullable(put(key, value));
@@ -120,6 +138,37 @@ public abstract class AbstractMutableHashBasedLongToRefDictionary<V, E extends L
     return removed.value();
   }
 
+  @Override
+  public boolean remove(long key, V expectedValue) {
+    @Nullable E[] entries = entries();
+    int hash = hash(Long.hashCode(key));
+    int entryIndex = indexFor(hash, entries.length);
+
+    E previosEntry = entries[entryIndex];
+    E entry = previosEntry;
+
+    while (entry != null) {
+      E nextEntry = entry.next();
+      if (entry.hash() == hash && key == entry.key()) {
+        if (Objects.equals(entry.value(), expectedValue)) {
+          decrementSize();
+          if (previosEntry == entry) {
+            entries[entryIndex] = nextEntry;
+          } else {
+            previosEntry.next(nextEntry);
+          }
+          return true;
+        } else {
+          return false;
+        }
+      }
+      previosEntry = entry;
+      entry = nextEntry;
+    }
+
+    return false;
+  }
+  
   @Override
   public Optional<V> removeOptional(long key) {
     return Optional.ofNullable(remove(key));

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedLongToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedLongToRefDictionary.java
@@ -94,7 +94,7 @@ public abstract class AbstractMutableHashBasedLongToRefDictionary<V, E extends L
 
     for (E entry = entries[entryIndex]; entry != null; entry = entry.next()) {
       if (entry.hash() == hash && key == entry.key()) {
-        return null;
+        return entry.value();
       }
     }
 
@@ -144,25 +144,25 @@ public abstract class AbstractMutableHashBasedLongToRefDictionary<V, E extends L
     int hash = hash(Long.hashCode(key));
     int entryIndex = indexFor(hash, entries.length);
 
-    E previosEntry = entries[entryIndex];
-    E entry = previosEntry;
+    E previousEntry = entries[entryIndex];
+    E entry = previousEntry;
 
     while (entry != null) {
       E nextEntry = entry.next();
       if (entry.hash() == hash && key == entry.key()) {
         if (Objects.equals(entry.value(), expectedValue)) {
           decrementSize();
-          if (previosEntry == entry) {
+          if (previousEntry == entry) {
             entries[entryIndex] = nextEntry;
           } else {
-            previosEntry.next(nextEntry);
+            previousEntry.next(nextEntry);
           }
           return true;
         } else {
           return false;
         }
       }
-      previosEntry = entry;
+      previousEntry = entry;
       entry = nextEntry;
     }
 

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedRefToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedRefToRefDictionary.java
@@ -93,7 +93,7 @@ public abstract class AbstractMutableHashBasedRefToRefDictionary<K, V, E extends
 
     for (E entry = entries[entryIndex]; entry != null; entry = entry.next()) {
       if (entry.hash() == hash && key.equals(entry.key())) {
-        return null;
+        return entry.value();
       }
     }
 
@@ -143,25 +143,25 @@ public abstract class AbstractMutableHashBasedRefToRefDictionary<K, V, E extends
     int hash = hash(key.hashCode());
     int entryIndex = indexFor(hash, entries.length);
 
-    E previosEntry = entries[entryIndex];
-    E entry = previosEntry;
+    E previousEntry = entries[entryIndex];
+    E entry = previousEntry;
 
     while (entry != null) {
       E nextEntry = entry.next();
       if (entry.hash() == hash && key.equals(entry.key())) {
         if (Objects.equals(entry.value(), expectedValue)) {
           decrementSize();
-          if (previosEntry == entry) {
+          if (previousEntry == entry) {
             entries[entryIndex] = nextEntry;
           } else {
-            previosEntry.next(nextEntry);
+            previousEntry.next(nextEntry);
           }
           return true;
         } else {
           return false;
         }
       }
-      previosEntry = entry;
+      previousEntry = entry;
       entry = nextEntry;
     }
 

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedRefToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedRefToRefDictionary.java
@@ -1,5 +1,6 @@
 package javasabr.rlib.collections.dictionary.impl;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -84,6 +85,23 @@ public abstract class AbstractMutableHashBasedRefToRefDictionary<K, V, E extends
   }
 
   @Override
+  @Nullable
+  public V putIfAbsent(K key, V value) {
+    @Nullable E[] entries = entries();
+    int hash = hash(key.hashCode());
+    int entryIndex = indexFor(hash, entries.length);
+
+    for (E entry = entries[entryIndex]; entry != null; entry = entry.next()) {
+      if (entry.hash() == hash && key.equals(entry.key())) {
+        return null;
+      }
+    }
+
+    addEntry(hash, key, value, entryIndex);
+    return null;
+  }
+
+  @Override
   public Optional<V> putOptional(K key, V value) {
     return Optional.ofNullable(put(key, value));
   }
@@ -117,6 +135,37 @@ public abstract class AbstractMutableHashBasedRefToRefDictionary<K, V, E extends
       return null;
     }
     return removed.value();
+  }
+
+  @Override
+  public boolean remove(K key, V expectedValue) {
+    @Nullable E[] entries = entries();
+    int hash = hash(key.hashCode());
+    int entryIndex = indexFor(hash, entries.length);
+
+    E previosEntry = entries[entryIndex];
+    E entry = previosEntry;
+
+    while (entry != null) {
+      E nextEntry = entry.next();
+      if (entry.hash() == hash && key.equals(entry.key())) {
+        if (Objects.equals(entry.value(), expectedValue)) {
+          decrementSize();
+          if (previosEntry == entry) {
+            entries[entryIndex] = nextEntry;
+          } else {
+            previosEntry.next(nextEntry);
+          }
+          return true;
+        } else {
+          return false;
+        }
+      }
+      previosEntry = entry;
+      entry = nextEntry;
+    }
+
+    return false;
   }
 
   @Override

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedRefToRefDictionary.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/AbstractMutableHashBasedRefToRefDictionary.java
@@ -84,8 +84,8 @@ public abstract class AbstractMutableHashBasedRefToRefDictionary<K, V, E extends
     return null;
   }
 
-  @Override
   @Nullable
+  @Override
   public V putIfAbsent(K key, V value) {
     @Nullable E[] entries = entries();
     int hash = hash(key.hashCode());

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/ArrayIterationsTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/ArrayIterationsTest.java
@@ -1,8 +1,9 @@
 package javasabr.rlib.collections.array;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -13,24 +14,28 @@ class ArrayIterationsTest {
   @MethodSource("generateArrays")
   void shouldFindAnyCorrectly(Array<String> array) {
     // when/then:
-    Assertions.assertNull(array
+    assertThat(array
         .iterations()
-        .findAny("notexist", Objects::equals));
-    Assertions.assertNotNull(array
+        .findAny("notexist", Objects::equals))
+        .isNull();
+    assertThat(array
         .iterations()
-        .findAny("Second", Objects::equals));
+        .findAny("Second", Objects::equals))
+        .isNotNull();
   }
 
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldFindAny2Correctly(Array<String> array) {
     // when/then:
-    Assertions.assertNull(array
+    assertThat(array
         .iterations()
-        .findAny(10, (element, intArg) -> String.valueOf(intArg).equals(element)));
-    Assertions.assertNotNull(array
+        .findAny(10, (element, intArg) -> String.valueOf(intArg).equals(element)))
+        .isNull();
+    assertThat(array
         .iterations()
-        .findAny(5, (element, intArg) -> String.valueOf(intArg).equals(element)));
+        .findAny(5, (element, intArg) -> String.valueOf(intArg).equals(element)))
+        .isNotNull();
   }
 
   @ParameterizedTest
@@ -50,7 +55,7 @@ class ArrayIterationsTest {
         .forEach("_postfix", (element, arg1) -> result.add(element + arg1));
 
     // then:
-    Assertions.assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @ParameterizedTest
@@ -70,7 +75,7 @@ class ArrayIterationsTest {
         .forEach("prefix_", "_postfix", (element, arg1, arg2) -> result.add(arg1 + element + arg2));
 
     // then:
-    Assertions.assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @ParameterizedTest
@@ -90,19 +95,21 @@ class ArrayIterationsTest {
         .forEach("prefix_", 55L, (element, arg1, arg2) -> result.add(arg1 + element + arg2));
 
     // then:
-    Assertions.assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldAnyMatchCorrectly(Array<String> array) {
     // when/then:
-    Assertions.assertFalse(array
+    assertThat(array
         .iterations()
-        .anyMatch(10, (element, intArg) -> String.valueOf(intArg).equals(element)));
-    Assertions.assertTrue(array
+        .anyMatch(10, (element, intArg) -> String.valueOf(intArg).equals(element)))
+        .isFalse();
+    assertThat(array
         .iterations()
-        .anyMatch(5, (element, intArg) -> String.valueOf(intArg).equals(element)));
+        .anyMatch(5, (element, intArg) -> String.valueOf(intArg).equals(element)))
+        .isTrue();
   }
 
   private static Stream<Arguments> generateArrays() {

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/ArrayTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/ArrayTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -67,80 +66,76 @@ public class ArrayTest  {
   void shouldCorrectlyTakeValues(Array<String> array) {
 
     // then:
-    Assertions.assertEquals(4, array.size());
-    Assertions.assertEquals("First", array.get(0));
-    Assertions.assertEquals("Second", array.get(1));
-    Assertions.assertEquals("Third", array.get(2));
-    Assertions.assertEquals("  ", array.get(3));
-    Assertions.assertEquals("First", array.first());
-    Assertions.assertEquals("  ", array.last());
+    assertThat(array.size()).isEqualTo(4);
+    assertThat(array.get(0)).isEqualTo("First");
+    assertThat(array.get(1)).isEqualTo("Second");
+    assertThat(array.get(2)).isEqualTo("Third");
+    assertThat(array.get(3)).isEqualTo("  ");
+    assertThat(array.first()).isEqualTo("First");
+    assertThat(array.last()).isEqualTo("  ");
 
     // then:
-    Assertions.assertArrayEquals(
-        new String[]{
+    assertThat(array.stream().toArray()).isEqualTo(new String[]{
             "First",
             "Second",
             "Third",
             "  "
-        }, array.stream().toArray());
+        });
 
     // then:
-    Assertions.assertTrue(array.contains("Second"));
-    Assertions.assertFalse(array.contains("test"));
+    assertThat(array.contains("Second")).isTrue();
+    assertThat(array.contains("test")).isFalse();
   }
 
   @ParameterizedTest
   @MethodSource("generateArraysWithDuplicates")
   void shouldFindElementIndex(Array<String> array) {
     // when/then:
-    Assertions.assertEquals(0, array.indexOf("First"));
-    Assertions.assertEquals(3, array.indexOf("  "));
-    Assertions.assertEquals(-1, array.indexOf("notexist"));
+    assertThat(array.indexOf("First")).isEqualTo(0);
+    assertThat(array.indexOf("  ")).isEqualTo(3);
+    assertThat(array.indexOf("notexist")).isEqualTo(-1);
   }
 
   @ParameterizedTest
   @MethodSource("generateArraysWithDuplicates")
   void shouldFindLastElementIndex(Array<String> array) {
     // when/then:
-    Assertions.assertEquals(4, array.lastIndexOf("First"));
-    Assertions.assertEquals(6, array.lastIndexOf("Third"));
-    Assertions.assertEquals(-1, array.lastIndexOf("notexist"));
+    assertThat(array.lastIndexOf("First")).isEqualTo(4);
+    assertThat(array.lastIndexOf("Third")).isEqualTo(6);
+    assertThat(array.lastIndexOf("notexist")).isEqualTo(-1);
   }
 
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldFindElementIndexWithFunction(Array<String> array) {
     // when/then:
-    Assertions.assertEquals(0, array.indexOf(s -> s + s, "FirstFirst"));
-    Assertions.assertEquals(3, array.indexOf(s -> s + s, "    "));
-    Assertions.assertEquals(-1, array.indexOf("notexist"));
+    assertThat(array.indexOf(s -> s + s, "FirstFirst")).isEqualTo(0);
+    assertThat(array.indexOf(s -> s + s, "    ")).isEqualTo(3);
+    assertThat(array.indexOf("notexist")).isEqualTo(-1);
   }
 
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldCorrectlyTransformToNativeArray(Array<String> array) {
     // then:
-    Assertions.assertArrayEquals(
-        new String[]{
+    assertThat(array.toArray()).isEqualTo(new String[]{
             "First",
             "Second",
             "Third",
             "  "
-        }, array.toArray());
-    Assertions.assertArrayEquals(
-        new String[]{
+        });
+    assertThat(array.toArray(new String[4])).isEqualTo(new String[]{
             "First",
             "Second",
             "Third",
             "  "
-        }, array.toArray(new String[4]));
-    Assertions.assertArrayEquals(
-        new String[]{
+        });
+    assertThat(array.toArray(String.class)).isEqualTo(new String[]{
             "First",
             "Second",
             "Third",
             "  "
-        }, array.toArray(String.class));
+        });
   }
 
   @ParameterizedTest

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/IntArrayTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/IntArrayTest.java
@@ -3,7 +3,6 @@ package javasabr.rlib.collections.array;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -49,47 +48,46 @@ public class IntArrayTest {
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldCorrectlyTakeValues(IntArray array) {
+    // then:
+    assertThat(array.size()).isEqualTo(4);
+    assertThat(array.get(0)).isEqualTo(5);
+    assertThat(array.get(1)).isEqualTo(8);
+    assertThat(array.get(2)).isEqualTo(13);
+    assertThat(array.get(3)).isEqualTo(25);
+    assertThat(array.first()).isEqualTo(5);
+    assertThat(array.last()).isEqualTo(25);
 
     // then:
-    Assertions.assertEquals(4, array.size());
-    Assertions.assertEquals(5, array.get(0));
-    Assertions.assertEquals(8, array.get(1));
-    Assertions.assertEquals(13, array.get(2));
-    Assertions.assertEquals(25, array.get(3));
-    Assertions.assertEquals(5, array.first());
-    Assertions.assertEquals(25, array.last());
+    assertThat(array.stream().toArray()).isEqualTo(new int[]{5, 8, 13, 25});
 
     // then:
-    Assertions.assertArrayEquals(new int[]{5, 8, 13, 25}, array.stream().toArray());
-
-    // then:
-    Assertions.assertTrue(array.contains(8));
-    Assertions.assertFalse(array.contains(99));
+    assertThat(array.contains(8)).isTrue();
+    assertThat(array.contains(99)).isFalse();
   }
 
   @ParameterizedTest
   @MethodSource("generateArraysWithDuplicates")
   void shouldFindElementIndex(IntArray array) {
     // when/then:
-    Assertions.assertEquals(0, array.indexOf(5));
-    Assertions.assertEquals(3, array.indexOf(25));
-    Assertions.assertEquals(-1, array.indexOf(99));
+    assertThat(array.indexOf(5)).isEqualTo(0);
+    assertThat(array.indexOf(25)).isEqualTo(3);
+    assertThat(array.indexOf(99)).isEqualTo(-1);
   }
 
   @ParameterizedTest
   @MethodSource("generateArraysWithDuplicates")
   void shouldFindLastElementIndex(IntArray array) {
     // when/then:
-    Assertions.assertEquals(4, array.lastIndexOf(5));
-    Assertions.assertEquals(6, array.lastIndexOf(13));
-    Assertions.assertEquals(-1, array.lastIndexOf(99));
+    assertThat(array.lastIndexOf(5)).isEqualTo(4);
+    assertThat(array.lastIndexOf(13)).isEqualTo(6);
+    assertThat(array.lastIndexOf(99)).isEqualTo(-1);
   }
 
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldCorrectlyTransformToNativeArray(IntArray array) {
     // when/then:
-    Assertions.assertArrayEquals(new int[]{5, 8, 13, 25}, array.stream().toArray());
+    assertThat(array.stream().toArray()).isEqualTo(new int[]{5, 8, 13, 25});
   }
 
   @ParameterizedTest

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/LongArrayTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/LongArrayTest.java
@@ -3,7 +3,6 @@ package javasabr.rlib.collections.array;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -49,47 +48,47 @@ public class LongArrayTest {
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldCorrectlyTakeValues(LongArray array) {
+    // then:
+    assertThat(array.size()).isEqualTo(4);
+    assertThat(array.get(0)).isEqualTo(5);
+    assertThat(array.get(1)).isEqualTo(8);
+    assertThat(array.get(2)).isEqualTo(13);
+    assertThat(array.get(3)).isEqualTo(25);
+    assertThat(array.first()).isEqualTo(5);
+    assertThat(array.last()).isEqualTo(25);
 
     // then:
-    Assertions.assertEquals(4, array.size());
-    Assertions.assertEquals(5, array.get(0));
-    Assertions.assertEquals(8, array.get(1));
-    Assertions.assertEquals(13, array.get(2));
-    Assertions.assertEquals(25, array.get(3));
-    Assertions.assertEquals(5, array.first());
-    Assertions.assertEquals(25, array.last());
+    assertThat(array.stream().toArray()).isEqualTo(new long[]{5, 8, 13, 25});
 
     // then:
-    Assertions.assertArrayEquals(new long[]{5, 8, 13, 25}, array.stream().toArray());
-
-    // then:
-    Assertions.assertTrue(array.contains(8));
-    Assertions.assertFalse(array.contains(99));
+    assertThat(array.contains(8)).isTrue();
+    assertThat(array.contains(99)).isFalse();
   }
 
   @ParameterizedTest
   @MethodSource("generateArraysWithDuplicates")
   void shouldFindElementIndex(LongArray array) {
     // when/then:
-    Assertions.assertEquals(0, array.indexOf(5));
-    Assertions.assertEquals(3, array.indexOf(25));
-    Assertions.assertEquals(-1, array.indexOf(99));
+    assertThat(array.indexOf(5)).isEqualTo(0);
+    assertThat(array.indexOf(25)).isEqualTo(3);
+    assertThat(array.indexOf(99)).isEqualTo(-1);
   }
 
   @ParameterizedTest
   @MethodSource("generateArraysWithDuplicates")
   void shouldFindLastElementIndex(LongArray array) {
     // when/then:
-    Assertions.assertEquals(4, array.lastIndexOf(5));
-    Assertions.assertEquals(6, array.lastIndexOf(13));
-    Assertions.assertEquals(-1, array.lastIndexOf(99));
+    assertThat(array.lastIndexOf(5)).isEqualTo(4);
+    assertThat(array.lastIndexOf(13)).isEqualTo(6);
+    assertThat(array.lastIndexOf(99)).isEqualTo(-1);
   }
 
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldCorrectlyTransformToNativeArray(LongArray array) {
     // when/then:
-    Assertions.assertArrayEquals(new long[]{5, 8, 13, 25}, array.stream().toArray());
+    assertThat(array.stream().toArray())
+        .isEqualTo(new long[]{5, 8, 13, 25});
   }
 
   @ParameterizedTest

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/MutableArrayTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/MutableArrayTest.java
@@ -1,9 +1,10 @@
 package javasabr.rlib.collections.array;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -19,23 +20,23 @@ class MutableArrayTest {
     mutableArray.add("First");
 
     // then:
-    Assertions.assertEquals(1, mutableArray.size());
-    Assertions.assertEquals("First", mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(1);
+    assertThat(mutableArray.get(0)).isEqualTo("First");
 
     // when:
     mutableArray.add("second");
 
     // then:
-    Assertions.assertEquals(2, mutableArray.size());
-    Assertions.assertEquals("second", mutableArray.get(1));
+    assertThat(mutableArray.size()).isEqualTo(2);
+    assertThat(mutableArray.get(1)).isEqualTo("second");
 
     // when:
     mutableArray.add("third");
 
     // then:
-    Assertions.assertEquals(3, mutableArray.size());
-    Assertions.assertEquals("third", mutableArray.get(2));
-    Assertions.assertEquals(Array.of("First", "second", "third"), mutableArray);
+    assertThat(mutableArray.size()).isEqualTo(3);
+    assertThat(mutableArray.get(2)).isEqualTo("third");
+    assertThat(mutableArray).isEqualTo(Array.of("First", "second", "third"));
 
     // when:
     for(int i = 0; i < 100; i++) {
@@ -43,8 +44,8 @@ class MutableArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(103, mutableArray.size());
-    Assertions.assertEquals("value_99", mutableArray.get(102));
+    assertThat(mutableArray.size()).isEqualTo(103);
+    assertThat(mutableArray.get(102)).isEqualTo("value_99");
   }
 
   @ParameterizedTest
@@ -60,25 +61,25 @@ class MutableArrayTest {
     mutableArray.remove("value_0");
 
     // then:
-    Assertions.assertEquals(100, mutableArray.size());
-    Assertions.assertEquals("value_1", mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(100);
+    assertThat(mutableArray.get(0)).isEqualTo("value_1");
 
     // when:
     mutableArray.remove("value_10");
 
     // then:
-    Assertions.assertEquals(99, mutableArray.size());
-    Assertions.assertEquals("value_1", mutableArray.get(0));
-    Assertions.assertEquals("value_9", mutableArray.get(8));
-    Assertions.assertEquals("value_11", mutableArray.get(9));
+    assertThat(mutableArray.size()).isEqualTo(99);
+    assertThat(mutableArray.get(0)).isEqualTo("value_1");
+    assertThat(mutableArray.get(8)).isEqualTo("value_9");
+    assertThat(mutableArray.get(9)).isEqualTo("value_11");
 
     // when:
     mutableArray.remove("value_100");
 
     // then:
-    Assertions.assertEquals(98, mutableArray.size());
-    Assertions.assertEquals("value_99", mutableArray.get(97));
-    Assertions.assertEquals("value_98", mutableArray.get(96));
+    assertThat(mutableArray.size()).isEqualTo(98);
+    assertThat(mutableArray.get(97)).isEqualTo("value_99");
+    assertThat(mutableArray.get(96)).isEqualTo("value_98");
   }
 
   @ParameterizedTest
@@ -94,15 +95,15 @@ class MutableArrayTest {
     mutableArray.replace(0, "value_200");
 
     // then:
-    Assertions.assertEquals(101, mutableArray.size());
-    Assertions.assertEquals("value_200", mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(101);
+    assertThat(mutableArray.get(0)).isEqualTo("value_200");
 
     // when:
     mutableArray.replace(11, "value_211");
 
     // then:
-    Assertions.assertEquals(101, mutableArray.size());
-    Assertions.assertEquals("value_211", mutableArray.get(11));
+    assertThat(mutableArray.size()).isEqualTo(101);
+    assertThat(mutableArray.get(11)).isEqualTo("value_211");
   }
 
   @ParameterizedTest
@@ -123,37 +124,37 @@ class MutableArrayTest {
     mutableArray.addAll(anotherArray);
 
     // then:
-    Assertions.assertEquals(27, mutableArray.size());
-    Assertions.assertEquals("value_0", mutableArray.get(0));
-    Assertions.assertEquals("value_20", mutableArray.get(20));
-    Assertions.assertEquals("a1", mutableArray.get(21));
-    Assertions.assertEquals("a6", mutableArray.get(26));
+    assertThat(mutableArray.size()).isEqualTo(27);
+    assertThat(mutableArray.get(0)).isEqualTo("value_0");
+    assertThat(mutableArray.get(20)).isEqualTo("value_20");
+    assertThat(mutableArray.get(21)).isEqualTo("a1");
+    assertThat(mutableArray.get(26)).isEqualTo("a6");
 
     // when:
     mutableArray.addAll(anotherList);
 
     // then:
-    Assertions.assertEquals(33, mutableArray.size());
-    Assertions.assertEquals("value_0", mutableArray.get(0));
-    Assertions.assertEquals("value_20", mutableArray.get(20));
-    Assertions.assertEquals("a1", mutableArray.get(21));
-    Assertions.assertEquals("a6", mutableArray.get(26));
-    Assertions.assertEquals("l1", mutableArray.get(27));
-    Assertions.assertEquals("l6", mutableArray.get(32));
+    assertThat(mutableArray.size()).isEqualTo(33);
+    assertThat(mutableArray.get(0)).isEqualTo("value_0");
+    assertThat(mutableArray.get(20)).isEqualTo("value_20");
+    assertThat(mutableArray.get(21)).isEqualTo("a1");
+    assertThat(mutableArray.get(26)).isEqualTo("a6");
+    assertThat(mutableArray.get(27)).isEqualTo("l1");
+    assertThat(mutableArray.get(32)).isEqualTo("l6");
 
     // when:
     mutableArray.addAll(anotherNativeArray);
 
     // then:
-    Assertions.assertEquals(39, mutableArray.size());
-    Assertions.assertEquals("value_0", mutableArray.get(0));
-    Assertions.assertEquals("value_20", mutableArray.get(20));
-    Assertions.assertEquals("a1", mutableArray.get(21));
-    Assertions.assertEquals("a6", mutableArray.get(26));
-    Assertions.assertEquals("l1", mutableArray.get(27));
-    Assertions.assertEquals("l6", mutableArray.get(32));
-    Assertions.assertEquals("na1", mutableArray.get(33));
-    Assertions.assertEquals("na6", mutableArray.get(38));
+    assertThat(mutableArray.size()).isEqualTo(39);
+    assertThat(mutableArray.get(0)).isEqualTo("value_0");
+    assertThat(mutableArray.get(20)).isEqualTo("value_20");
+    assertThat(mutableArray.get(21)).isEqualTo("a1");
+    assertThat(mutableArray.get(26)).isEqualTo("a6");
+    assertThat(mutableArray.get(27)).isEqualTo("l1");
+    assertThat(mutableArray.get(32)).isEqualTo("l6");
+    assertThat(mutableArray.get(33)).isEqualTo("na1");
+    assertThat(mutableArray.get(38)).isEqualTo("na6");
   }
 
   @ParameterizedTest
@@ -178,13 +179,13 @@ class MutableArrayTest {
     mutableArray.removeAll(anotherList);
 
     // then:
-    Assertions.assertEquals(33, mutableArray.size());
-    Assertions.assertEquals("value_0", mutableArray.get(0));
-    Assertions.assertEquals("value_20", mutableArray.get(20));
-    Assertions.assertEquals("a1", mutableArray.get(21));
-    Assertions.assertEquals("a6", mutableArray.get(26));
-    Assertions.assertEquals("na1", mutableArray.get(27));
-    Assertions.assertEquals("na6", mutableArray.get(32));
+    assertThat(mutableArray.size()).isEqualTo(33);
+    assertThat(mutableArray.get(0)).isEqualTo("value_0");
+    assertThat(mutableArray.get(20)).isEqualTo("value_20");
+    assertThat(mutableArray.get(21)).isEqualTo("a1");
+    assertThat(mutableArray.get(26)).isEqualTo("a6");
+    assertThat(mutableArray.get(27)).isEqualTo("na1");
+    assertThat(mutableArray.get(32)).isEqualTo("na6");
   }
 
   @ParameterizedTest
@@ -197,16 +198,16 @@ class MutableArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(21, mutableArray.size());
-    Assertions.assertEquals("value_0", mutableArray.get(0));
-    Assertions.assertEquals("value_20", mutableArray.get(20));
+    assertThat(mutableArray.size()).isEqualTo(21);
+    assertThat(mutableArray.get(0)).isEqualTo("value_0");
+    assertThat(mutableArray.get(20)).isEqualTo("value_20");
 
     // when:
     mutableArray.clear();
 
     // then:
-    Assertions.assertEquals(0, mutableArray.size());
-    Assertions.assertArrayEquals(new String[0], mutableArray.toArray());
+    assertThat(mutableArray.size()).isEqualTo(0);
+    assertThat(mutableArray.toArray()).isEqualTo(new String[0]);
   }
 
   @ParameterizedTest
@@ -222,7 +223,7 @@ class MutableArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(100, mutableArray.size());
+    assertThat(mutableArray.size()).isEqualTo(100);
 
     // when:
     for(int i = 0; i < 30; i++) {
@@ -230,14 +231,14 @@ class MutableArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(70, mutableArray.size());
-    Assertions.assertEquals(109, unsafe.wrapped().length);
+    assertThat(mutableArray.size()).isEqualTo(70);
+    assertThat(unsafe.wrapped().length).isEqualTo(109);
 
     // when:
     unsafe.trimToSize();
 
     // then:
-    Assertions.assertEquals(70, unsafe.wrapped().length);
+    assertThat(unsafe.wrapped().length).isEqualTo(70);
   }
 
   @ParameterizedTest
@@ -249,9 +250,8 @@ class MutableArrayTest {
       mutableArray.add("val_" + i);
     }
     // then:
-    Assertions.assertEquals(
-        "[val_0, val_1, val_2, val_3, val_4, val_5, val_6, val_7, val_8, val_9]",
-        mutableArray.toString());
+    assertThat(mutableArray.toString())
+        .isEqualTo("[val_0, val_1, val_2, val_3, val_4, val_5, val_6, val_7, val_8, val_9]");
   }
 
   @ParameterizedTest
@@ -266,7 +266,7 @@ class MutableArrayTest {
     
     // then:
     var expected = Array.of("10", "25", "3", "45", "5", "56", "77", "99");
-    Assertions.assertEquals(expected, mutableArray);
+    assertThat(mutableArray).isEqualTo(expected);
   }
 
   @ParameterizedTest
@@ -281,7 +281,7 @@ class MutableArrayTest {
 
     // then:
     var expected = Array.of("3", "5", "10", "25", "45", "56", "77", "99");
-    Assertions.assertEquals(expected, mutableArray);
+    assertThat(mutableArray).isEqualTo(expected);
   }
 
   private static Stream<Arguments> generateMutableArrays() {

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/MutableIntArrayTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/MutableIntArrayTest.java
@@ -1,7 +1,8 @@
 package javasabr.rlib.collections.array;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,23 +18,23 @@ class MutableIntArrayTest {
     mutableArray.add(10);
 
     // then:
-    Assertions.assertEquals(1, mutableArray.size());
-    Assertions.assertEquals(10, mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(1);
+    assertThat(mutableArray.get(0)).isEqualTo(10);
 
     // when:
     mutableArray.add(20);
 
     // then:
-    Assertions.assertEquals(2, mutableArray.size());
-    Assertions.assertEquals(20, mutableArray.get(1));
+    assertThat(mutableArray.size()).isEqualTo(2);
+    assertThat(mutableArray.get(1)).isEqualTo(20);
 
     // when:
     mutableArray.add(30);
 
     // then:
-    Assertions.assertEquals(3, mutableArray.size());
-    Assertions.assertEquals(30, mutableArray.get(2));
-    Assertions.assertEquals(IntArray.of(10, 20, 30), mutableArray);
+    assertThat(mutableArray.size()).isEqualTo(3);
+    assertThat(mutableArray.get(2)).isEqualTo(30);
+    assertThat(mutableArray).isEqualTo(IntArray.of(10, 20, 30));
 
     // when:
     for(int i = 0; i < 100; i++) {
@@ -41,8 +42,8 @@ class MutableIntArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(103, mutableArray.size());
-    Assertions.assertEquals(199, mutableArray.get(102));
+    assertThat(mutableArray.size()).isEqualTo(103);
+    assertThat(mutableArray.get(102)).isEqualTo(199);
   }
 
   @ParameterizedTest
@@ -58,25 +59,25 @@ class MutableIntArrayTest {
     mutableArray.remove(100);
 
     // then:
-    Assertions.assertEquals(100, mutableArray.size());
-    Assertions.assertEquals(101, mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(100);
+    assertThat(mutableArray.get(0)).isEqualTo(101);
 
     // when:
     mutableArray.remove(110);
 
     // then:
-    Assertions.assertEquals(99, mutableArray.size());
-    Assertions.assertEquals(101, mutableArray.get(0));
-    Assertions.assertEquals(109, mutableArray.get(8));
-    Assertions.assertEquals(111, mutableArray.get(9));
+    assertThat(mutableArray.size()).isEqualTo(99);
+    assertThat(mutableArray.get(0)).isEqualTo(101);
+    assertThat(mutableArray.get(8)).isEqualTo(109);
+    assertThat(mutableArray.get(9)).isEqualTo(111);
 
     // when:
     mutableArray.remove(200);
 
     // then:
-    Assertions.assertEquals(98, mutableArray.size());
-    Assertions.assertEquals(199, mutableArray.get(97));
-    Assertions.assertEquals(198, mutableArray.get(96));
+    assertThat(mutableArray.size()).isEqualTo(98);
+    assertThat(mutableArray.get(97)).isEqualTo(199);
+    assertThat(mutableArray.get(96)).isEqualTo(198);
   }
 
   @ParameterizedTest
@@ -92,15 +93,15 @@ class MutableIntArrayTest {
     mutableArray.replace(0, 200);
 
     // then:
-    Assertions.assertEquals(101, mutableArray.size());
-    Assertions.assertEquals(200, mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(101);
+    assertThat(mutableArray.get(0)).isEqualTo(200);
 
     // when:
     mutableArray.replace(11, 211);
 
     // then:
-    Assertions.assertEquals(101, mutableArray.size());
-    Assertions.assertEquals(211, mutableArray.get(11));
+    assertThat(mutableArray.size()).isEqualTo(101);
+    assertThat(mutableArray.get(11)).isEqualTo(211);
   }
 
   @ParameterizedTest
@@ -119,23 +120,23 @@ class MutableIntArrayTest {
     mutableArray.addAll(anotherArray);
 
     // then:
-    Assertions.assertEquals(27, mutableArray.size());
-    Assertions.assertEquals(100, mutableArray.get(0));
-    Assertions.assertEquals(120, mutableArray.get(20));
-    Assertions.assertEquals(31, mutableArray.get(21));
-    Assertions.assertEquals(36, mutableArray.get(26));
+    assertThat(mutableArray.size()).isEqualTo(27);
+    assertThat(mutableArray.get(0)).isEqualTo(100);
+    assertThat(mutableArray.get(20)).isEqualTo(120);
+    assertThat(mutableArray.get(21)).isEqualTo(31);
+    assertThat(mutableArray.get(26)).isEqualTo(36);
 
     // when:
     mutableArray.addAll(anotherNativeArray);
 
     // then:
-    Assertions.assertEquals(33, mutableArray.size());
-    Assertions.assertEquals(100, mutableArray.get(0));
-    Assertions.assertEquals(120, mutableArray.get(20));
-    Assertions.assertEquals(31, mutableArray.get(21));
-    Assertions.assertEquals(36, mutableArray.get(26));
-    Assertions.assertEquals(41, mutableArray.get(27));
-    Assertions.assertEquals(46, mutableArray.get(32));
+    assertThat(mutableArray.size()).isEqualTo(33);
+    assertThat(mutableArray.get(0)).isEqualTo(100);
+    assertThat(mutableArray.get(20)).isEqualTo(120);
+    assertThat(mutableArray.get(21)).isEqualTo(31);
+    assertThat(mutableArray.get(26)).isEqualTo(36);
+    assertThat(mutableArray.get(27)).isEqualTo(41);
+    assertThat(mutableArray.get(32)).isEqualTo(46);
   }
 
   @ParameterizedTest
@@ -157,17 +158,17 @@ class MutableIntArrayTest {
     mutableArray.removeAll(anotherArray);
 
     // then:
-    Assertions.assertEquals(27, mutableArray.size());
-    Assertions.assertEquals(100, mutableArray.get(0));
-    Assertions.assertEquals(120, mutableArray.get(20));
-    Assertions.assertEquals(41, mutableArray.get(21));
-    Assertions.assertEquals(46, mutableArray.get(26));
+    assertThat(mutableArray.size()).isEqualTo(27);
+    assertThat(mutableArray.get(0)).isEqualTo(100);
+    assertThat(mutableArray.get(20)).isEqualTo(120);
+    assertThat(mutableArray.get(21)).isEqualTo(41);
+    assertThat(mutableArray.get(26)).isEqualTo(46);
 
     // when:
     mutableArray.removeAll(anotherNativeArray);
 
     // then:
-    Assertions.assertEquals(21, mutableArray.size());
+    assertThat(mutableArray.size()).isEqualTo(21);
   }
 
   @ParameterizedTest
@@ -180,16 +181,16 @@ class MutableIntArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(21, mutableArray.size());
-    Assertions.assertEquals(100, mutableArray.get(0));
-    Assertions.assertEquals(120, mutableArray.get(20));
+    assertThat(mutableArray.size()).isEqualTo(21);
+    assertThat(mutableArray.get(0)).isEqualTo(100);
+    assertThat(mutableArray.get(20)).isEqualTo(120);
 
     // when:
     mutableArray.clear();
 
     // then:
-    Assertions.assertEquals(0, mutableArray.size());
-    Assertions.assertArrayEquals(new int[0], mutableArray.toArray());
+    assertThat(mutableArray.size()).isEqualTo(0);
+    assertThat(mutableArray.toArray()).isEqualTo(new int[0]);
   }
 
   @ParameterizedTest
@@ -205,7 +206,7 @@ class MutableIntArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(100, mutableArray.size());
+    assertThat(mutableArray.size()).isEqualTo(100);
 
     // when:
     for(int i = 0; i < 30; i++) {
@@ -213,14 +214,14 @@ class MutableIntArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(70, mutableArray.size());
-    Assertions.assertEquals(109, unsafe.wrapped().length);
+    assertThat(mutableArray.size()).isEqualTo(70);
+    assertThat(unsafe.wrapped().length).isEqualTo(109);
 
     // when:
     unsafe.trimToSize();
 
     // then:
-    Assertions.assertEquals(70, unsafe.wrapped().length);
+    assertThat(unsafe.wrapped().length).isEqualTo(70);
   }
 
   @ParameterizedTest
@@ -232,7 +233,8 @@ class MutableIntArrayTest {
       mutableArray.add(20 + i);
     }
     // then:
-    Assertions.assertEquals("[20,21,22,23,24,25,26,27,28,29]", mutableArray.toString());
+    assertThat(mutableArray.toString())
+        .isEqualTo("[20,21,22,23,24,25,26,27,28,29]");
   }
 
   private static Stream<Arguments> generateMutableArrays() {

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/MutableLongArrayTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/MutableLongArrayTest.java
@@ -1,7 +1,8 @@
 package javasabr.rlib.collections.array;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,23 +18,23 @@ class MutableLongArrayTest {
     mutableArray.add(10);
 
     // then:
-    Assertions.assertEquals(1, mutableArray.size());
-    Assertions.assertEquals(10, mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(1);
+    assertThat(mutableArray.get(0)).isEqualTo(10);
 
     // when:
     mutableArray.add(20);
 
     // then:
-    Assertions.assertEquals(2, mutableArray.size());
-    Assertions.assertEquals(20, mutableArray.get(1));
+    assertThat(mutableArray.size()).isEqualTo(2);
+    assertThat(mutableArray.get(1)).isEqualTo(20);
 
     // when:
     mutableArray.add(30);
 
     // then:
-    Assertions.assertEquals(3, mutableArray.size());
-    Assertions.assertEquals(30, mutableArray.get(2));
-    Assertions.assertEquals(LongArray.of(10, 20, 30), mutableArray);
+    assertThat(mutableArray.size()).isEqualTo(3);
+    assertThat(mutableArray.get(2)).isEqualTo(30);
+    assertThat(mutableArray).isEqualTo(LongArray.of(10, 20, 30));
 
     // when:
     for(int i = 0; i < 100; i++) {
@@ -41,8 +42,8 @@ class MutableLongArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(103, mutableArray.size());
-    Assertions.assertEquals(199, mutableArray.get(102));
+    assertThat(mutableArray.size()).isEqualTo(103);
+    assertThat(mutableArray.get(102)).isEqualTo(199);
   }
 
   @ParameterizedTest
@@ -58,25 +59,25 @@ class MutableLongArrayTest {
     mutableArray.remove(100);
 
     // then:
-    Assertions.assertEquals(100, mutableArray.size());
-    Assertions.assertEquals(101, mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(100);
+    assertThat(mutableArray.get(0)).isEqualTo(101);
 
     // when:
     mutableArray.remove(110);
 
     // then:
-    Assertions.assertEquals(99, mutableArray.size());
-    Assertions.assertEquals(101, mutableArray.get(0));
-    Assertions.assertEquals(109, mutableArray.get(8));
-    Assertions.assertEquals(111, mutableArray.get(9));
+    assertThat(mutableArray.size()).isEqualTo(99);
+    assertThat(mutableArray.get(0)).isEqualTo(101);
+    assertThat(mutableArray.get(8)).isEqualTo(109);
+    assertThat(mutableArray.get(9)).isEqualTo(111);
 
     // when:
     mutableArray.remove(200);
 
     // then:
-    Assertions.assertEquals(98, mutableArray.size());
-    Assertions.assertEquals(199, mutableArray.get(97));
-    Assertions.assertEquals(198, mutableArray.get(96));
+    assertThat(mutableArray.size()).isEqualTo(98);
+    assertThat(mutableArray.get(97)).isEqualTo(199);
+    assertThat(mutableArray.get(96)).isEqualTo(198);
   }
 
   @ParameterizedTest
@@ -92,15 +93,15 @@ class MutableLongArrayTest {
     mutableArray.replace(0, 200);
 
     // then:
-    Assertions.assertEquals(101, mutableArray.size());
-    Assertions.assertEquals(200, mutableArray.get(0));
+    assertThat(mutableArray.size()).isEqualTo(101);
+    assertThat(mutableArray.get(0)).isEqualTo(200);
 
     // when:
     mutableArray.replace(11, 211);
 
     // then:
-    Assertions.assertEquals(101, mutableArray.size());
-    Assertions.assertEquals(211, mutableArray.get(11));
+    assertThat(mutableArray.size()).isEqualTo(101);
+    assertThat(mutableArray.get(11)).isEqualTo(211);
   }
 
   @ParameterizedTest
@@ -119,23 +120,23 @@ class MutableLongArrayTest {
     mutableArray.addAll(anotherArray);
 
     // then:
-    Assertions.assertEquals(27, mutableArray.size());
-    Assertions.assertEquals(100, mutableArray.get(0));
-    Assertions.assertEquals(120, mutableArray.get(20));
-    Assertions.assertEquals(31, mutableArray.get(21));
-    Assertions.assertEquals(36, mutableArray.get(26));
+    assertThat(mutableArray.size()).isEqualTo(27);
+    assertThat(mutableArray.get(0)).isEqualTo(100);
+    assertThat(mutableArray.get(20)).isEqualTo(120);
+    assertThat(mutableArray.get(21)).isEqualTo(31);
+    assertThat(mutableArray.get(26)).isEqualTo(36);
 
     // when:
     mutableArray.addAll(anotherNativeArray);
 
     // then:
-    Assertions.assertEquals(33, mutableArray.size());
-    Assertions.assertEquals(100, mutableArray.get(0));
-    Assertions.assertEquals(120, mutableArray.get(20));
-    Assertions.assertEquals(31, mutableArray.get(21));
-    Assertions.assertEquals(36, mutableArray.get(26));
-    Assertions.assertEquals(41, mutableArray.get(27));
-    Assertions.assertEquals(46, mutableArray.get(32));
+    assertThat(mutableArray.size()).isEqualTo(33);
+    assertThat(mutableArray.get(0)).isEqualTo(100);
+    assertThat(mutableArray.get(20)).isEqualTo(120);
+    assertThat(mutableArray.get(21)).isEqualTo(31);
+    assertThat(mutableArray.get(26)).isEqualTo(36);
+    assertThat(mutableArray.get(27)).isEqualTo(41);
+    assertThat(mutableArray.get(32)).isEqualTo(46);
   }
 
   @ParameterizedTest
@@ -157,17 +158,17 @@ class MutableLongArrayTest {
     mutableArray.removeAll(anotherArray);
 
     // then:
-    Assertions.assertEquals(27, mutableArray.size());
-    Assertions.assertEquals(100, mutableArray.get(0));
-    Assertions.assertEquals(120, mutableArray.get(20));
-    Assertions.assertEquals(41, mutableArray.get(21));
-    Assertions.assertEquals(46, mutableArray.get(26));
+    assertThat(mutableArray.size()).isEqualTo(27);
+    assertThat(mutableArray.get(0)).isEqualTo(100);
+    assertThat(mutableArray.get(20)).isEqualTo(120);
+    assertThat(mutableArray.get(21)).isEqualTo(41);
+    assertThat(mutableArray.get(26)).isEqualTo(46);
 
     // when:
     mutableArray.removeAll(anotherNativeArray);
 
     // then:
-    Assertions.assertEquals(21, mutableArray.size());
+    assertThat(mutableArray.size()).isEqualTo(21);
   }
 
   @ParameterizedTest
@@ -180,16 +181,16 @@ class MutableLongArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(21, mutableArray.size());
-    Assertions.assertEquals(100, mutableArray.get(0));
-    Assertions.assertEquals(120, mutableArray.get(20));
+    assertThat(mutableArray.size()).isEqualTo(21);
+    assertThat(mutableArray.get(0)).isEqualTo(100);
+    assertThat(mutableArray.get(20)).isEqualTo(120);
 
     // when:
     mutableArray.clear();
 
     // then:
-    Assertions.assertEquals(0, mutableArray.size());
-    Assertions.assertArrayEquals(new long[0], mutableArray.toArray());
+    assertThat(mutableArray.size()).isEqualTo(0);
+    assertThat(mutableArray.toArray()).isEqualTo(new long[0]);
   }
 
   @ParameterizedTest
@@ -205,7 +206,8 @@ class MutableLongArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(100, mutableArray.size());
+    assertThat(mutableArray.size())
+        .isEqualTo(100);
 
     // when:
     for(int i = 0; i < 30; i++) {
@@ -213,14 +215,17 @@ class MutableLongArrayTest {
     }
 
     // then:
-    Assertions.assertEquals(70, mutableArray.size());
-    Assertions.assertEquals(109, unsafe.wrapped().length);
+    assertThat(mutableArray.size())
+        .isEqualTo(70);
+    assertThat(unsafe.wrapped().length)
+        .isEqualTo(109);
 
     // when:
     unsafe.trimToSize();
 
     // then:
-    Assertions.assertEquals(70, unsafe.wrapped().length);
+    assertThat(unsafe.wrapped().length)
+        .isEqualTo(70);
   }
 
   @ParameterizedTest
@@ -232,7 +237,8 @@ class MutableLongArrayTest {
       mutableArray.add(20 + i);
     }
     // then:
-    Assertions.assertEquals("[20,21,22,23,24,25,26,27,28,29]", mutableArray.toString());
+    assertThat(mutableArray.toString())
+        .isEqualTo("[20,21,22,23,24,25,26,27,28,29]");
   }
 
   private static Stream<Arguments> generateMutableArrays() {

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/array/ReversedArrayIterationsTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/array/ReversedArrayIterationsTest.java
@@ -1,8 +1,9 @@
 package javasabr.rlib.collections.array;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -13,13 +14,15 @@ class ReversedArrayIterationsTest {
   @MethodSource("generateArrays")
   void shouldFindAnyCorrectly(Array<String> array) {
     // when/then:
-    Assertions.assertNull(array
+    assertThat(array
         .iterations()
         .reversedArgs()
-        .findAny("notexist", Objects::equals));
-    Assertions.assertNotNull(array
+        .findAny("notexist", Objects::equals))
+        .isNull();
+    assertThat(array
         .iterations()
-        .findAny("Second", Objects::equals));
+        .findAny("Second", Objects::equals))
+        .isNotNull();
   }
 
   @ParameterizedTest
@@ -40,7 +43,7 @@ class ReversedArrayIterationsTest {
         .forEach("prefix_", (arg1, element) -> result.add(arg1 + element));
 
     // then:
-    Assertions.assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @ParameterizedTest
@@ -62,21 +65,21 @@ class ReversedArrayIterationsTest {
         .forEach("prefix_", "_middle_", (arg1, arg2, element) -> result.add(arg1 + arg2 + element));
 
     // then:
-    Assertions.assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 
   @ParameterizedTest
   @MethodSource("generateArrays")
   void shouldAnyMatchCorrectly(Array<String> array) {
     // when/then:
-    Assertions.assertFalse(array
+    assertThat(array
         .iterations()
         .reversedArgs()
-        .anyMatch("10", String::equals));
-    Assertions.assertTrue(array
+        .anyMatch("10", String::equals)).isFalse();
+    assertThat(array
         .iterations()
         .reversedArgs()
-        .anyMatch("5", String::equals));
+        .anyMatch("5", String::equals)).isTrue();
   }
 
   private static Stream<Arguments> generateArrays() {

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/deque/DequeTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/deque/DequeTest.java
@@ -1,10 +1,8 @@
 package javasabr.rlib.collections.deque;
 
 import static javasabr.rlib.common.util.ArrayUtils.array;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.reflect.Field;
 import java.util.Deque;
@@ -17,7 +15,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javasabr.rlib.collections.array.MutableArray;
 import javasabr.rlib.common.util.ReflectionUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -28,20 +25,21 @@ class DequeTest {
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldAddFirst(Deque<String> deque) {
-
     // when:
     deque.addFirst("val1");
     deque.addFirst("val2");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val2", "val1"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val2", "val1"));
 
     // when:
     deque.addFirst("val3");
     deque.addFirst("val4");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val4", "val3", "val2", "val1"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val4", "val3", "val2", "val1"));
 
     // when:
     deque.addFirst("val5");
@@ -54,40 +52,49 @@ class DequeTest {
     deque.addFirst("val12");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val12", "val11", "val10", "val9", "val8",
-        "val7", "val6", "val5", "val4", "val3", "val2", "val1"));
+    assertThat(deque.toArray())
+        .isEqualTo(array(
+            "val12",
+            "val11", 
+            "val10", 
+            "val9", 
+            "val8", 
+            "val7", 
+            "val6", 
+            "val5", 
+            "val4", 
+            "val3", 
+            "val2", 
+            "val1"));
   }
 
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldAddFirstManyElements(Deque<String> deque) {
-
     // when:
     IntStream.range(1, 200)
         .mapToObj(value -> "val_" + value)
         .forEach(deque::addFirst);
 
     // then:
-    assertEquals(199, deque.size());
+    assertThat(deque.size()).isEqualTo(199);
   }
 
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldAddLastManyElements(Deque<String> deque) {
-
     // when:
     IntStream.range(1, 200)
         .mapToObj(value -> "val_" + value)
         .forEach(deque::addLast);
 
     // then:
-    assertEquals(199, deque.size());
+    assertThat(deque.size()).isEqualTo(199);
   }
 
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldAddFirstLastManyElements(Deque<String> deque) {
-
     // when:
     IntStream
         .range(1, 500)
@@ -101,7 +108,7 @@ class DequeTest {
         });
 
     // then:
-    assertEquals(499, deque.size());
+    assertThat(deque.size()).isEqualTo(499);
   }
 
   @ParameterizedTest
@@ -137,20 +144,21 @@ class DequeTest {
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldAddLast(Deque<String> deque) {
-
     // when:
     deque.addLast("val1");
     deque.addLast("val2");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val1", "val2"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val2"));
 
     // when:
     deque.addLast("val3");
     deque.addLast("val4");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val1", "val2", "val3", "val4"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val2", "val3", "val4"));
 
     // when:
     deque.addLast("val5");
@@ -163,27 +171,40 @@ class DequeTest {
     deque.addLast("val12");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val1", "val2", "val3", "val4", "val5",
-        "val6", "val7", "val8", "val9", "val10", "val11", "val12"));
+    assertThat(deque.toArray())
+        .isEqualTo(array(
+            "val1",
+            "val2", 
+            "val3",
+            "val4",
+            "val5", 
+            "val6",
+            "val7",
+            "val8",
+            "val9", 
+            "val10", 
+            "val11", 
+            "val12"));
   }
 
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldAddFirstAndAddLastInMixMode(Deque<String> deque) {
-
     // when:
     deque.addFirst("val1");
     deque.addFirst("val2");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val2", "val1"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val2", "val1"));
 
     // when:
     deque.addLast("val3");
     deque.addLast("val4");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val2", "val1", "val3", "val4"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val2", "val1", "val3", "val4"));
 
     // when:
     deque.addFirst("val5");
@@ -196,14 +217,25 @@ class DequeTest {
     deque.addLast("val12");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val11", "val7", "val6", "val5", "val2",
-        "val1", "val3", "val4", "val8", "val9", "val10", "val12"));
+    assertThat(deque.toArray())
+        .isEqualTo(array(
+            "val11",
+            "val7", 
+            "val6",
+            "val5",
+            "val2", 
+            "val1",
+            "val3",
+            "val4", 
+            "val8", 
+            "val9", 
+            "val10", 
+            "val12"));
   }
 
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldRemoveFirst(Deque<String> deque) {
-
     // given:
     deque.addAll(List.of("val1", "val2", "val3", "val4", "val5"));
 
@@ -212,28 +244,29 @@ class DequeTest {
     var removed2 = deque.removeFirst();
 
     // then:
-    assertEquals("val1", removed1);
-    assertEquals("val2", removed2);
-    assertArrayEquals(deque.toArray(), array("val3", "val4", "val5"));
+    assertThat(removed1).isEqualTo("val1");
+    assertThat(removed2).isEqualTo("val2");
+    assertThat(deque.toArray())
+        .isEqualTo(array("val3", "val4", "val5"));
 
     // when:
     var removed3 = deque.removeFirst();
     var removed4 = deque.removeFirst();
 
     // then:
-    assertEquals("val3", removed3);
-    assertEquals("val4", removed4);
-    assertArrayEquals(deque.toArray(), array("val5"));
+    assertThat(removed3).isEqualTo("val3");
+    assertThat(removed4).isEqualTo("val4");
+    assertThat(deque.toArray()).isEqualTo(array("val5"));
 
     // when:
     var removed5 = deque.removeFirst();
 
     // then:
-    assertEquals("val5", removed5);
-    assertArrayEquals(deque.toArray(), array());
+    assertThat(removed5).isEqualTo("val5");
+    assertThat(deque.toArray()).isEqualTo(array());
 
     // when/then:
-    Assertions.assertThrows(NoSuchElementException.class, deque::removeFirst);
+    assertThatThrownBy(deque::removeFirst).isInstanceOf(NoSuchElementException.class);
   }
 
   @ParameterizedTest
@@ -248,28 +281,29 @@ class DequeTest {
     var removed2 = deque.removeLast();
 
     // then:
-    assertEquals("val5", removed1);
-    assertEquals("val4", removed2);
-    assertArrayEquals(deque.toArray(), array("val1", "val2", "val3"));
+    assertThat(removed1).isEqualTo("val5");
+    assertThat(removed2).isEqualTo("val4");
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val2", "val3"));
 
     // when:
     var removed3 = deque.removeLast();
     var removed4 = deque.removeLast();
 
     // then:
-    assertEquals("val3", removed3);
-    assertEquals("val2", removed4);
-    assertArrayEquals(deque.toArray(), array("val1"));
+    assertThat(removed3).isEqualTo("val3");
+    assertThat(removed4).isEqualTo("val2");
+    assertThat(deque.toArray()).isEqualTo(array("val1"));
 
     // when:
     var removed5 = deque.removeLast();
 
     // then:
-    assertEquals("val1", removed5);
-    assertArrayEquals(deque.toArray(), array());
+    assertThat(removed5).isEqualTo("val1");
+    assertThat(deque.toArray()).isEqualTo(array());
 
     // when/then:
-    Assertions.assertThrows(NoSuchElementException.class, deque::removeLast);
+    assertThatThrownBy(deque::removeLast).isInstanceOf(NoSuchElementException.class);
   }
 
   @ParameterizedTest
@@ -284,18 +318,20 @@ class DequeTest {
     var removed2 = deque.removeLast();
 
     // then:
-    assertEquals("val1", removed1);
-    assertEquals("val8", removed2);
-    assertArrayEquals(deque.toArray(), array("val2", "val3", "val4", "val5", "val6", "val7"));
+    assertThat(removed1).isEqualTo("val1");
+    assertThat(removed2).isEqualTo("val8");
+    assertThat(deque.toArray())
+        .isEqualTo(array("val2", "val3", "val4", "val5", "val6", "val7"));
 
     // when:
     var removed3 = deque.removeFirst();
     var removed4 = deque.removeLast();
 
     // then:
-    assertEquals("val2", removed3);
-    assertEquals("val7", removed4);
-    assertArrayEquals(deque.toArray(), array("val3", "val4", "val5", "val6"));
+    assertThat(removed3).isEqualTo("val2");
+    assertThat(removed4).isEqualTo("val7");
+    assertThat(deque.toArray())
+        .isEqualTo(array("val3", "val4", "val5", "val6"));
 
     // when:
     var removed5 = deque.removeFirst();
@@ -304,15 +340,17 @@ class DequeTest {
     var removed8 = deque.removeLast();
 
     // then:
-    assertEquals("val3", removed5);
-    assertEquals("val4", removed6);
-    assertEquals("val6", removed7);
-    assertEquals("val5", removed8);
-    assertArrayEquals(deque.toArray(), array());
+    assertThat(removed5).isEqualTo("val3");
+    assertThat(removed6).isEqualTo("val4");
+    assertThat(removed7).isEqualTo("val6");
+    assertThat(removed8).isEqualTo("val5");
+    assertThat(deque.toArray()).isEqualTo(array());
 
     // when/then:
-    Assertions.assertThrows(NoSuchElementException.class, deque::removeFirst);
-    Assertions.assertThrows(NoSuchElementException.class, deque::removeLast);
+    assertThatThrownBy(deque::removeFirst)
+        .isInstanceOf(NoSuchElementException.class);
+    assertThatThrownBy(deque::removeLast)
+        .isInstanceOf(NoSuchElementException.class);
   }
 
   @ParameterizedTest
@@ -326,57 +364,61 @@ class DequeTest {
     deque.remove("val9");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8", "val10"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8", "val10"));
 
     // when:
     deque.remove("val2");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val1", "val3", "val4", "val5", "val6", "val7", "val8", "val10"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val3", "val4", "val5", "val6", "val7", "val8", "val10"));
 
     // when:
     deque.remove("val5");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val1", "val3", "val4", "val6", "val7", "val8", "val10"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val3", "val4", "val6", "val7", "val8", "val10"));
 
     // when:
     deque.remove("val6");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val1", "val3", "val4", "val7", "val8", "val10"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val3", "val4", "val7", "val8", "val10"));
 
     // when:
     deque.remove("val1");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val3", "val4", "val7", "val8", "val10"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val3", "val4", "val7", "val8", "val10"));
 
     // when:
     deque.remove("val10");
 
     // then:
-    assertArrayEquals(deque.toArray(), array("val3", "val4", "val7", "val8"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val3", "val4", "val7", "val8"));
   }
 
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldCheckContains(Deque<String> deque) {
-
     // given:
     deque.addAll(List.of("val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8", "val9", "val10"));
 
     // when/then:
-    assertTrue(deque.contains("val1"));
-    assertTrue(deque.contains("val10"));
-    assertTrue(deque.contains("val3"));
-    assertTrue(deque.contains("val8"));
-    assertFalse(deque.contains("val55"));
+    assertThat(deque.contains("val1")).isTrue();
+    assertThat(deque.contains("val10")).isTrue();
+    assertThat(deque.contains("val3")).isTrue();
+    assertThat(deque.contains("val8")).isTrue();
+    assertThat(deque.contains("val55")).isFalse();
   }
 
   @Test
   void shouldRebalanceIndexesAddLastRemoveFirst() {
-
     // given:
     Deque<String> deque = DequeFactory.arrayBasedBased(String.class, 15);
     Field head = ReflectionUtils.getUnsafeField(deque, "head");
@@ -395,9 +437,9 @@ class DequeTest {
     int tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(18, headValue);
-    assertEquals(19, tailValue);
-    assertEquals(2, deque.size());
+    assertThat(headValue).isEqualTo(18);
+    assertThat(tailValue).isEqualTo(19);
+    assertThat(deque.size()).isEqualTo(2);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -411,9 +453,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(29, headValue);
-    assertEquals(32, tailValue);
-    assertEquals(4, deque.size());
+    assertThat(headValue).isEqualTo(29);
+    assertThat(tailValue).isEqualTo(32);
+    assertThat(deque.size()).isEqualTo(4);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -427,9 +469,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(40, headValue);
-    assertEquals(45, tailValue);
-    assertEquals(6, deque.size());
+    assertThat(headValue).isEqualTo(40);
+    assertThat(tailValue).isEqualTo(45);
+    assertThat(deque.size()).isEqualTo(6);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -443,9 +485,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(31, headValue);
-    assertEquals(38, tailValue);
-    assertEquals(8, deque.size());
+    assertThat(headValue).isEqualTo(31);
+    assertThat(tailValue).isEqualTo(38);
+    assertThat(deque.size()).isEqualTo(8);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -459,9 +501,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(42, headValue);
-    assertEquals(51, tailValue);
-    assertEquals(10, deque.size());
+    assertThat(headValue).isEqualTo(42);
+    assertThat(tailValue).isEqualTo(51);
+    assertThat(deque.size()).isEqualTo(10);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -475,9 +517,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(30, headValue);
-    assertEquals(41, tailValue);
-    assertEquals(12, deque.size());
+    assertThat(headValue).isEqualTo(30);
+    assertThat(tailValue).isEqualTo(41);
+    assertThat(deque.size()).isEqualTo(12);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -491,14 +533,13 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(41, headValue);
-    assertEquals(54, tailValue);
-    assertEquals(14, deque.size());
+    assertThat(headValue).isEqualTo(41);
+    assertThat(tailValue).isEqualTo(54);
+    assertThat(deque.size()).isEqualTo(14);
   }
 
   @Test
   void shouldRebalanceIndexesAddFirstRemoveLast() {
-
     // given:
     Deque<String> deque = DequeFactory.arrayBasedBased(String.class, 15);
     Field head = ReflectionUtils.getUnsafeField(deque, "head");
@@ -517,9 +558,9 @@ class DequeTest {
     int tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(5, headValue);
-    assertEquals(6, tailValue);
-    assertEquals(2, deque.size());
+    assertThat(headValue).isEqualTo(5);
+    assertThat(tailValue).isEqualTo(6);
+    assertThat(deque.size()).isEqualTo(2);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -533,9 +574,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(2, headValue);
-    assertEquals(5, tailValue);
-    assertEquals(4, deque.size());
+    assertThat(headValue).isEqualTo(2);
+    assertThat(tailValue).isEqualTo(5);
+    assertThat(deque.size()).isEqualTo(4);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -549,9 +590,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(9, headValue);
-    assertEquals(14, tailValue);
-    assertEquals(6, deque.size());
+    assertThat(headValue).isEqualTo(9);
+    assertThat(tailValue).isEqualTo(14);
+    assertThat(deque.size()).isEqualTo(6);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -565,9 +606,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(25, headValue);
-    assertEquals(32, tailValue);
-    assertEquals(8, deque.size());
+    assertThat(headValue).isEqualTo(25);
+    assertThat(tailValue).isEqualTo(32);
+    assertThat(deque.size()).isEqualTo(8);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -581,9 +622,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(12, headValue);
-    assertEquals(21, tailValue);
-    assertEquals(10, deque.size());
+    assertThat(headValue).isEqualTo(12);
+    assertThat(tailValue).isEqualTo(21);
+    assertThat(deque.size()).isEqualTo(10);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -597,9 +638,9 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(31, headValue);
-    assertEquals(42, tailValue);
-    assertEquals(12, deque.size());
+    assertThat(headValue).isEqualTo(31);
+    assertThat(tailValue).isEqualTo(42);
+    assertThat(deque.size()).isEqualTo(12);
 
     // when:
     for (int i = 1; i < 14; i++) {
@@ -613,15 +654,14 @@ class DequeTest {
     tailValue = ReflectionUtils.getFieldValue(deque, tail);
 
     // then:
-    assertEquals(18, headValue);
-    assertEquals(31, tailValue);
-    assertEquals(14, deque.size());
+    assertThat(headValue).isEqualTo(18);
+    assertThat(tailValue).isEqualTo(31);
+    assertThat(deque.size()).isEqualTo(14);
   }
 
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldCorrectlyIterateDeque(Deque<String> deque) {
-
     // given:
     deque.addAll(List.of("val1", "val2", "val3", "val4", "val5", "val6"));
     var container = MutableArray.ofType(String.class);
@@ -636,14 +676,15 @@ class DequeTest {
     }
 
     // then:
-    assertArrayEquals(container.toArray(), array("val1", "val2", "val3", "val4", "val5", "val6"));
-    assertArrayEquals(deque.toArray(), array("val1", "val3", "val5", "val6"));
+    assertThat(container.toArray())
+        .isEqualTo(array("val1", "val2", "val3", "val4", "val5", "val6"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val3", "val5", "val6"));
   }
 
   @ParameterizedTest
   @MethodSource("generateDeque")
   void shouldCorrectlyIterate2Deque(Deque<String> deque) {
-
     // given:
     deque.addAll(List.of("val1", "val2", "val3", "val4", "val5", "val6"));
     var container = MutableArray.ofType(String.class);
@@ -658,8 +699,9 @@ class DequeTest {
     }
 
     // then:
-   // assertArrayEquals(container.toArray(), array("val6", "val5", "val4", "val3", "val2", "val1"));
-    assertArrayEquals(array("val1", "val3", "val5", "val6"), deque.toArray());
+   // assertThat(container.toArray()).isEqualTo(array("val6", "val5", "val4", "val3", "val2", "val1"));
+    assertThat(deque.toArray())
+        .isEqualTo(array("val1", "val3", "val5", "val6"));
   }
 
   private static Stream<Arguments> generateDeque() {

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableIntToRefDictionaryTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableIntToRefDictionaryTest.java
@@ -32,6 +32,33 @@ class MutableIntToRefDictionaryTest {
 
   @ParameterizedTest
   @MethodSource("generateDictionaries")
+  void shouldPutIfAbsentNewPairs(MutableIntToRefDictionary<String> dictionary) {
+    // given:
+    dictionary.put(1, "val1");
+    dictionary.put(4, "val4");
+    dictionary.put(7, "val7");
+    dictionary.put(55, "val55");
+    // when:
+    String result1 = dictionary.putIfAbsent(1, "val1_1");
+    String result2 = dictionary.putIfAbsent(4, "val4_1");
+    String result3 = dictionary.putIfAbsent(44, "val44");
+    // then:
+    assertThat(result1).isNull();
+    assertThat(result2).isNull();
+    assertThat(result3).isNull();
+    assertThat(dictionary.get(1)).isEqualTo("val1");
+    assertThat(dictionary.get(4)).isEqualTo("val4");
+    assertThat(dictionary.get(55)).isEqualTo("val55");
+    assertThat(dictionary.get(44)).isEqualTo("val44");
+    assertThat(dictionary.containsKey(1)).isTrue();
+    assertThat(dictionary.containsKey(4)).isTrue();
+    assertThat(dictionary.containsKey(55)).isTrue();
+    assertThat(dictionary.containsKey(44)).isTrue();
+    assertThat(dictionary.size()).isEqualTo(5);
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateDictionaries")
   void shouldPutOptionalNewPairs(MutableIntToRefDictionary<String> dictionary) {
     // when:
     dictionary.put(4, "val4");
@@ -70,6 +97,31 @@ class MutableIntToRefDictionaryTest {
     assertThat(dictionary.containsKey(1)).isFalse();
     assertThat(dictionary.containsKey(55)).isFalse();
     assertThat(dictionary.size()).isEqualTo(2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateDictionaries")
+  void shouldRemoveByKeysWithExpectedValues(MutableIntToRefDictionary<String> dictionary) {
+    // given:
+    dictionary.put(1, "val1");
+    dictionary.put(4, "val4");
+    dictionary.put(7, "val7");
+    dictionary.put(55, "val55");
+
+    // when:
+    boolean removed1 = dictionary.remove(1, "val2");
+    boolean removed2 = dictionary.remove(55, "val55");
+
+    // then:
+    assertThat(removed1).isFalse();
+    assertThat(removed2).isTrue();
+    assertThat(dictionary.get(4)).isEqualTo("val4");
+    assertThat(dictionary.get(7)).isEqualTo("val7");
+    assertThat(dictionary.get(1)).isEqualTo("val1");
+    assertThat(dictionary.get(55)).isNull();
+    assertThat(dictionary.containsKey(1)).isTrue();
+    assertThat(dictionary.containsKey(55)).isFalse();
+    assertThat(dictionary.size()).isEqualTo(3);
   }
 
   @ParameterizedTest

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableIntToRefDictionaryTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableIntToRefDictionaryTest.java
@@ -43,8 +43,8 @@ class MutableIntToRefDictionaryTest {
     String result2 = dictionary.putIfAbsent(4, "val4_1");
     String result3 = dictionary.putIfAbsent(44, "val44");
     // then:
-    assertThat(result1).isNull();
-    assertThat(result2).isNull();
+    assertThat(result1).isEqualTo("val1");
+    assertThat(result2).isEqualTo("val4");
     assertThat(result3).isNull();
     assertThat(dictionary.get(1)).isEqualTo("val1");
     assertThat(dictionary.get(4)).isEqualTo("val4");

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableLongToRefDictionaryTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableLongToRefDictionaryTest.java
@@ -43,8 +43,8 @@ class MutableLongToRefDictionaryTest {
     String result2 = dictionary.putIfAbsent(4, "val4_1");
     String result3 = dictionary.putIfAbsent(44, "val44");
     // then:
-    assertThat(result1).isNull();
-    assertThat(result2).isNull();
+    assertThat(result1).isEqualTo("val1");
+    assertThat(result2).isEqualTo("val4");
     assertThat(result3).isNull();
     assertThat(dictionary.get(1)).isEqualTo("val1");
     assertThat(dictionary.get(4)).isEqualTo("val4");

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableLongToRefDictionaryTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableLongToRefDictionaryTest.java
@@ -32,6 +32,33 @@ class MutableLongToRefDictionaryTest {
 
   @ParameterizedTest
   @MethodSource("generateDictionaries")
+  void shouldPutIfAbsentNewPairs(MutableLongToRefDictionary<String> dictionary) {
+    // given:
+    dictionary.put(1, "val1");
+    dictionary.put(4, "val4");
+    dictionary.put(7, "val7");
+    dictionary.put(55, "val55");
+    // when:
+    String result1 = dictionary.putIfAbsent(1, "val1_1");
+    String result2 = dictionary.putIfAbsent(4, "val4_1");
+    String result3 = dictionary.putIfAbsent(44, "val44");
+    // then:
+    assertThat(result1).isNull();
+    assertThat(result2).isNull();
+    assertThat(result3).isNull();
+    assertThat(dictionary.get(1)).isEqualTo("val1");
+    assertThat(dictionary.get(4)).isEqualTo("val4");
+    assertThat(dictionary.get(55)).isEqualTo("val55");
+    assertThat(dictionary.get(44)).isEqualTo("val44");
+    assertThat(dictionary.containsKey(1)).isTrue();
+    assertThat(dictionary.containsKey(4)).isTrue();
+    assertThat(dictionary.containsKey(55)).isTrue();
+    assertThat(dictionary.containsKey(44)).isTrue();
+    assertThat(dictionary.size()).isEqualTo(5);
+  }
+  
+  @ParameterizedTest
+  @MethodSource("generateDictionaries")
   void shouldPutOptionalNewPairs(MutableLongToRefDictionary<String> dictionary) {
     // when:
     dictionary.put(4, "val4");
@@ -70,6 +97,31 @@ class MutableLongToRefDictionaryTest {
     assertThat(dictionary.containsKey(1)).isFalse();
     assertThat(dictionary.containsKey(55)).isFalse();
     assertThat(dictionary.size()).isEqualTo(2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateDictionaries")
+  void shouldRemoveByKeysWithExpectedValues(MutableLongToRefDictionary<String> dictionary) {
+    // given:
+    dictionary.put(1, "val1");
+    dictionary.put(4, "val4");
+    dictionary.put(7, "val7");
+    dictionary.put(55, "val55");
+
+    // when:
+    boolean removed1 = dictionary.remove(1, "val2");
+    boolean removed2 = dictionary.remove(55, "val55");
+
+    // then:
+    assertThat(removed1).isFalse();
+    assertThat(removed2).isTrue();
+    assertThat(dictionary.get(4)).isEqualTo("val4");
+    assertThat(dictionary.get(7)).isEqualTo("val7");
+    assertThat(dictionary.get(1)).isEqualTo("val1");
+    assertThat(dictionary.get(55)).isNull();
+    assertThat(dictionary.containsKey(1)).isTrue();
+    assertThat(dictionary.containsKey(55)).isFalse();
+    assertThat(dictionary.size()).isEqualTo(3);
   }
 
   @ParameterizedTest

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionaryTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionaryTest.java
@@ -32,6 +32,33 @@ class MutableRefToRefDictionaryTest {
 
   @ParameterizedTest
   @MethodSource("generateDictionaries")
+  void shouldPutIfAbsentNewPairs(MutableRefToRefDictionary<String, String> dictionary) {
+    // given:
+    dictionary.put("key1", "val1");
+    dictionary.put("key4", "val4");
+    dictionary.put("key7", "val7");
+    dictionary.put("key55", "val55");
+    // when:
+    String result1 = dictionary.putIfAbsent("key1", "val1_1");
+    String result2 = dictionary.putIfAbsent("key4", "val4_1");
+    String result3 = dictionary.putIfAbsent("key44", "val44");
+    // then:
+    assertThat(result1).isNull();
+    assertThat(result2).isNull();
+    assertThat(result3).isNull();
+    assertThat(dictionary.get("key1")).isEqualTo("val1");
+    assertThat(dictionary.get("key4")).isEqualTo("val4");
+    assertThat(dictionary.get("key55")).isEqualTo("val55");
+    assertThat(dictionary.get("key44")).isEqualTo("val44");
+    assertThat(dictionary.containsKey("key1")).isTrue();
+    assertThat(dictionary.containsKey("key4")).isTrue();
+    assertThat(dictionary.containsKey("key55")).isTrue();
+    assertThat(dictionary.containsKey("key44")).isTrue();
+    assertThat(dictionary.size()).isEqualTo(5);
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateDictionaries")
   void shouldPutOptionalNewPairs(MutableRefToRefDictionary<String, String> dictionary) {
     // when:
     dictionary.put("key4", "val4");
@@ -70,6 +97,31 @@ class MutableRefToRefDictionaryTest {
     assertThat(dictionary.containsKey("key1")).isFalse();
     assertThat(dictionary.containsKey("key55")).isFalse();
     assertThat(dictionary.size()).isEqualTo(2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateDictionaries")
+  void shouldRemoveByKeysWithExpectedValues(MutableRefToRefDictionary<String, String> dictionary) {
+    // given:
+    dictionary.put("key1", "val1");
+    dictionary.put("key4", "val4");
+    dictionary.put("key7", "val7");
+    dictionary.put("key55", "val55");
+
+    // when:
+    boolean removed1 = dictionary.remove("key1", "val2");
+    boolean removed2 = dictionary.remove("key55", "val55");
+
+    // then:
+    assertThat(removed1).isFalse();
+    assertThat(removed2).isTrue();
+    assertThat(dictionary.get("key4")).isEqualTo("val4");
+    assertThat(dictionary.get("key7")).isEqualTo("val7");
+    assertThat(dictionary.get("key1")).isEqualTo("val1");
+    assertThat(dictionary.get("key55")).isNull();
+    assertThat(dictionary.containsKey("key1")).isTrue();
+    assertThat(dictionary.containsKey("key55")).isFalse();
+    assertThat(dictionary.size()).isEqualTo(3);
   }
 
   @ParameterizedTest

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionaryTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionaryTest.java
@@ -43,8 +43,8 @@ class MutableRefToRefDictionaryTest {
     String result2 = dictionary.putIfAbsent("key4", "val4_1");
     String result3 = dictionary.putIfAbsent("key44", "val44");
     // then:
-    assertThat(result1).isNull();
-    assertThat(result2).isNull();
+    assertThat(result1).isEqualTo("val1");
+    assertThat(result2).isEqualTo("val4");
     assertThat(result3).isNull();
     assertThat(dictionary.get("key1")).isEqualTo("val1");
     assertThat(dictionary.get("key4")).isEqualTo("val4");

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/operation/DefaultLockableOperationsTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/operation/DefaultLockableOperationsTest.java
@@ -1,9 +1,10 @@
 package javasabr.rlib.collections.operation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javasabr.rlib.collections.operation.impl.DefaultLockableOperations;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -52,200 +53,189 @@ class DefaultLockableOperationsTest {
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldGetInReadLock(DefaultLockableOperations<TestLockableSource> operations) {
-
     // when:
     var result = operations.getInReadLock(source -> {
-      Assertions.assertEquals(0, source.writeLocks);
-      Assertions.assertEquals(1, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(0);
+      assertThat(source.readLocks).isEqualTo(1);
       return "test";
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("test", result);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(result).isEqualTo("test");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldGetInReadLock2(DefaultLockableOperations<TestLockableSource> operations) {
-
     // when:
     var result = operations.getInReadLock("_arg", (source, arg1) -> {
-      Assertions.assertEquals(0, source.writeLocks);
-      Assertions.assertEquals(1, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(0);
+      assertThat(source.readLocks).isEqualTo(1);
       return "test" + arg1;
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("test_arg", result);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(result).isEqualTo("test_arg");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldGetInReadLock3(DefaultLockableOperations<TestLockableSource> operations) {
-
     // when:
     var result = operations.getInReadLock(15, (source, arg1) -> {
-      Assertions.assertEquals(0, source.writeLocks);
-      Assertions.assertEquals(1, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(0);
+      assertThat(source.readLocks).isEqualTo(1);
       return "test" + arg1;
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("test15", result);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(result).isEqualTo("test15");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldGetInReadLock4(DefaultLockableOperations<TestLockableSource> operations) {
-
     // when:
     var result = operations.getInReadLock("arg1_", "_arg2", (source, arg1, arg2) -> {
-      Assertions.assertEquals(0, source.writeLocks);
-      Assertions.assertEquals(1, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(0);
+      assertThat(source.readLocks).isEqualTo(1);
       return arg1 + "test" + arg2;
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("arg1_test_arg2", result);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(result).isEqualTo("arg1_test_arg2");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldGetInReadLock5(DefaultLockableOperations<TestLockableSource> operations) {
-
     // when:
     var result = operations.getInReadLock(true, (source, arg1) -> {
-      Assertions.assertEquals(0, source.writeLocks);
-      Assertions.assertEquals(1, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(0);
+      assertThat(source.readLocks).isEqualTo(1);
       return "test" + arg1;
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("testtrue", result);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(result).isEqualTo("testtrue");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldInReadLock(DefaultLockableOperations<TestLockableSource> operations) {
-
     // given:
     var capture = new AtomicReference<String>();
 
     // when:
     operations.inReadLock("test_arg", (source, arg1) -> {
-      Assertions.assertEquals(0, source.writeLocks);
-      Assertions.assertEquals(1, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(0);
+      assertThat(source.readLocks).isEqualTo(1);
       capture.set("test_" + arg1);
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("test_test_arg", capture.get());
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(capture.get()).isEqualTo("test_test_arg");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldGetWriteLock(DefaultLockableOperations<TestLockableSource> operations) {
-
     // when:
     var result = operations.getInWriteLock("_arg", (source, arg1) -> {
-      Assertions.assertEquals(1, source.writeLocks);
-      Assertions.assertEquals(0, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(1);
+      assertThat(source.readLocks).isEqualTo(0);
       return "test" + arg1;
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals("test_arg", result);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(result).isEqualTo("test_arg");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldGetWriteLock2(DefaultLockableOperations<TestLockableSource> operations) {
-
     // when:
     var result = operations.getInWriteLock("arg1_", "_arg2", (source, arg1, arg2) -> {
-      Assertions.assertEquals(1, source.writeLocks);
-      Assertions.assertEquals(0, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(1);
+      assertThat(source.readLocks).isEqualTo(0);
       return arg1 + "test" + arg2;
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals("arg1_test_arg2", result);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(result).isEqualTo("arg1_test_arg2");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldInWriteLock(DefaultLockableOperations<TestLockableSource> operations) {
-
     // given:
     var capture = new AtomicReference<String>();
 
     // when:
     operations.inWriteLock(source -> {
-      Assertions.assertEquals(1, source.writeLocks);
-      Assertions.assertEquals(0, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(1);
+      assertThat(source.readLocks).isEqualTo(0);
       capture.set("test");
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("test", capture.get());
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(capture.get()).isEqualTo("test");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldInWriteLock2(DefaultLockableOperations<TestLockableSource> operations) {
-
     // given:
     var capture = new AtomicReference<String>();
 
     // when:
     operations.inWriteLock("test_arg", (source, arg1) -> {
-      Assertions.assertEquals(1, source.writeLocks);
-      Assertions.assertEquals(0, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(1);
+      assertThat(source.readLocks).isEqualTo(0);
       capture.set("test_" + arg1);
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("test_test_arg", capture.get());
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(capture.get()).isEqualTo("test_test_arg");
   }
 
   @ParameterizedTest
   @MethodSource("generateOperations")
   void shouldInWriteLock3(DefaultLockableOperations<TestLockableSource> operations) {
-
     // given:
     var capture = new AtomicReference<String>();
 
     // when:
     operations.inWriteLock("arg1_", "_arg2", (source, arg1, arg2) -> {
-      Assertions.assertEquals(1, source.writeLocks);
-      Assertions.assertEquals(0, source.readLocks);
+      assertThat(source.writeLocks).isEqualTo(1);
+      assertThat(source.readLocks).isEqualTo(0);
       capture.set(arg1 + "test" + arg2);
     });
 
     // then:
-    Assertions.assertEquals(0, operations.source().writeLocks);
-    Assertions.assertEquals(0, operations.source().readLocks);
-    Assertions.assertEquals("arg1_test_arg2", capture.get());
+    assertThat(operations.source().writeLocks).isEqualTo(0);
+    assertThat(operations.source().readLocks).isEqualTo(0);
+    assertThat(capture.get()).isEqualTo("arg1_test_arg2");
   }
 
   private static Stream<Arguments> generateOperations() {

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/AliasedEnumMapTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/AliasedEnumMapTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 import javasabr.rlib.common.AliasedEnum;
 import org.jspecify.annotations.NonNull;

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/BufferUtilsTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/BufferUtilsTest.java
@@ -1,7 +1,8 @@
 package javasabr.rlib.common.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -18,10 +19,10 @@ class BufferUtilsTest {
 
     var source = BufferUtils.loadFrom(data, ByteBuffer.allocate(12));
 
-    Assertions.assertEquals(0, source.position());
-    Assertions.assertEquals(4, source.limit());
-    Assertions.assertEquals(1, source.getInt());
-    Assertions.assertFalse(data.hasRemaining());
+    assertThat(source.position()).isEqualTo(0);
+    assertThat(source.limit()).isEqualTo(4);
+    assertThat(source.getInt()).isEqualTo(1);
+    assertThat(data.hasRemaining()).isFalse();
 
     data.clear();
     data
@@ -38,12 +39,12 @@ class BufferUtilsTest {
 
     BufferUtils.loadFrom(data, source);
 
-    Assertions.assertEquals(source.capacity(), data.position());
-    Assertions.assertEquals(0, source.position());
-    Assertions.assertEquals(source.capacity(), source.remaining());
-    Assertions.assertEquals(1, source.getInt());
-    Assertions.assertEquals(2, source.getInt());
-    Assertions.assertEquals(3, source.getInt());
+    assertThat(data.position()).isEqualTo(source.capacity());
+    assertThat(source.position()).isEqualTo(0);
+    assertThat(source.remaining()).isEqualTo(source.capacity());
+    assertThat(source.getInt()).isEqualTo(1);
+    assertThat(source.getInt()).isEqualTo(2);
+    assertThat(source.getInt()).isEqualTo(3);
   }
 
   @Test
@@ -56,10 +57,10 @@ class BufferUtilsTest {
           buffer.put((byte) 3);
         });
 
-    Assertions.assertEquals(3, result.limit());
-    Assertions.assertEquals(0, result.position());
-    Assertions.assertEquals(1, result.get());
-    Assertions.assertEquals(2, result.get());
-    Assertions.assertEquals(3, result.get());
+    assertThat(result.limit()).isEqualTo(3);
+    assertThat(result.position()).isEqualTo(0);
+    assertThat(result.get()).isEqualTo((byte) 1);
+    assertThat(result.get()).isEqualTo((byte) 2);
+    assertThat(result.get()).isEqualTo((byte) 3);
   }
 }

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/DateUtilsTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/DateUtilsTest.java
@@ -2,74 +2,81 @@ package javasabr.rlib.common.util;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DateUtilsTest {
 
   @Test
   void stringToLocalDateTest() {
+    assertThat(DateUtils.toLocalDate("1800-05-20"))
+        .isEqualTo(LocalDate.of(1800, 5, 20));
 
-    Assertions.assertEquals(LocalDate.of(1800, 5, 20), DateUtils.toLocalDate("1800-05-20"));
+    assertThat(DateUtils.toLocalDate("2020-1-10"))
+        .isNull();
+    assertThat(DateUtils.toLocalDate("2020-01-10"))
+        .isEqualTo(LocalDate.of(2020, 1, 10));
 
-    Assertions.assertNull(DateUtils.toLocalDate("2020-1-10"));
-    Assertions.assertEquals(LocalDate.of(2020, 1, 10), DateUtils.toLocalDate("2020-01-10"));
+    assertThat(DateUtils.toLocalDate("2015-5-1"))
+        .isNull();
+    assertThat(DateUtils.toLocalDate("2015-05-01"))
+        .isEqualTo(LocalDate.of(2015, 5, 1));
 
-    Assertions.assertNull(DateUtils.toLocalDate("2015-5-1"));
-    Assertions.assertEquals(LocalDate.of(2015, 5, 1), DateUtils.toLocalDate("2015-05-01"));
-
-    Assertions.assertNull(DateUtils.toLocalDate("invaliddate"));
+    assertThat(DateUtils.toLocalDate("invaliddate"))
+        .isNull();
   }
 
   @Test
   void localDateToStringTest() {
+    assertThat(DateUtils.toString(LocalDate.of(1800, 5, 20)))
+        .isEqualTo("1800-05-20");
 
-    Assertions.assertEquals("1800-05-20", DateUtils.toString(LocalDate.of(1800, 5, 20)));
+    assertThat(DateUtils.toString(LocalDate.of(2020, 1, 10)))
+        .isEqualTo("2020-01-10");
 
-    Assertions.assertEquals("2020-01-10", DateUtils.toString(LocalDate.of(2020, 1, 10)));
+    assertThat(DateUtils.toString(LocalDate.of(2015, 5, 1)))
+        .isEqualTo("2015-05-01");
 
-    Assertions.assertEquals("2015-05-01", DateUtils.toString(LocalDate.of(2015, 5, 1)));
-
-    Assertions.assertNull(DateUtils.toString(null));
+    assertThat(DateUtils.toString(null))
+        .isNull();
   }
 
   @Test
   void temporalAccessorToStringTest() {
+    assertThat(DateUtils.toString(LocalDate.of(1800, 5, 20), ISO_LOCAL_DATE))
+        .isEqualTo("1800-05-20");
 
-    Assertions.assertEquals("1800-05-20", DateUtils.toString(LocalDate.of(1800, 5, 20), ISO_LOCAL_DATE));
+    assertThat(DateUtils.toString(LocalDateTime.of(2020, 1, 10, 23, 42), ISO_LOCAL_DATE_TIME))
+        .isEqualTo("2020-01-10T23:42:00");
 
-    Assertions.assertEquals(
-        "2020-01-10T23:42:00",
-        DateUtils.toString(LocalDateTime.of(2020, 1, 10, 23, 42), ISO_LOCAL_DATE_TIME));
-
-    Assertions.assertNull(DateUtils.toString(null, ISO_LOCAL_DATE));
+    assertThat(DateUtils.toString(null, ISO_LOCAL_DATE))
+        .isNull();
   }
 
   @Test
   void formatTimestampTest() {
-
     var localDateTime = LocalDateTime.of(2010, 5, 12, 23, 10, 35, 0);
 
-    Assertions.assertEquals("23:10:35:000", DateUtils.formatShortTimestamp(localDateTime));
-    Assertions.assertEquals(
-        "23:10:35:000",
-        DateUtils.formatShortTimestamp(localDateTime
+    assertThat(DateUtils.formatShortTimestamp(localDateTime))
+        .isEqualTo("23:10:35:000");
+    assertThat(DateUtils.formatShortTimestamp(localDateTime
             .toInstant(ZoneOffset.UTC)
-            .toEpochMilli()));
+            .toEpochMilli()))
+        .isEqualTo("23:10:35:000");
 
     var zonedDateTime = ZonedDateTime.of(2010, 5, 12, 23, 10, 35, 0, ZoneOffset.ofHours(3));
 
-    Assertions.assertEquals("23:10:35:000", DateUtils.formatShortTimestamp(zonedDateTime));
-    Assertions.assertEquals(
-        "23:10:35:000",
-        DateUtils.formatShortTimestamp(zonedDateTime
+    assertThat(DateUtils.formatShortTimestamp(zonedDateTime))
+        .isEqualTo("23:10:35:000");
+    assertThat(DateUtils.formatShortTimestamp(zonedDateTime
             .toLocalDateTime()
             .toInstant(ZoneOffset.UTC)
-            .toEpochMilli()));
+            .toEpochMilli()))
+        .isEqualTo("23:10:35:000");
   }
 }

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/NumberUtilsTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/NumberUtilsTest.java
@@ -137,19 +137,22 @@ class NumberUtilsTest {
 
   @Test
   void shouldWriteHighLowBitsCorrectly() {
-
     for (int low = 0; low < 16; low++) {
       for (int high = 0; high < 16; high++) {
         var result = NumberUtils.setHighByteBits(low, high);
-        assertThat(NumberUtils.getHighByteBits(result)).isEqualTo(high);
-        assertThat(NumberUtils.getLowByteBits(result)).isEqualTo(low);
+        assertThat(NumberUtils.getHighByteBits(result))
+            .isEqualTo((byte) high);
+        assertThat(NumberUtils.getLowByteBits(result))
+            .isEqualTo((byte) low);
       }
     }
 
     for (int low = 0; low < 16; low++) {
       var result = NumberUtils.setLowByteBits(256, low);
-      assertThat(NumberUtils.getHighByteBits(result)).isEqualTo(16);
-      assertThat(NumberUtils.getLowByteBits(result)).isEqualTo(low);
+      assertThat(NumberUtils.getHighByteBits(result))
+          .isEqualTo((byte) 16);
+      assertThat(NumberUtils.getLowByteBits(result))
+          .isEqualTo((byte) low);
     }
   }
 
@@ -157,35 +160,35 @@ class NumberUtilsTest {
   void shouldReadHighLowBitsCorrectly() {
     for (int i = 0; i < 16; i++) {
       assertThat(NumberUtils.getHighByteBits(i << 4))
-          .isEqualTo(i);
+          .isEqualTo((byte) i);
     }
 
     assertThat(NumberUtils.getHighByteBits(0b1000_0100))
-        .isEqualTo(0b0000_1000);
+        .isEqualTo((byte) 0b0000_1000);
     assertThat(NumberUtils.getHighByteBits(0b0100_1000))
-        .isEqualTo(0b0000_0100);
+        .isEqualTo((byte) 0b0000_0100);
     assertThat(NumberUtils.getHighByteBits(0b0010_0010))
-        .isEqualTo(0b0000_0010);
+        .isEqualTo((byte) 0b0000_0010);
     assertThat(NumberUtils.getHighByteBits(0b0001_0001))
-        .isEqualTo(0b0000_0001);
+        .isEqualTo((byte) 0b0000_0001);
     assertThat(NumberUtils.getHighByteBits(0b0101_1000))
-        .isEqualTo(0b0000_0101);
+        .isEqualTo((byte) 0b0000_0101);
 
     for (int i = 0; i < 16; i++) {
       assertThat(NumberUtils.getLowByteBits(i & 0x0F))
-          .isEqualTo(i);
+          .isEqualTo((byte) i);
     }
 
     assertThat(NumberUtils.getLowByteBits(0b1000_1000))
-        .isEqualTo(0b0000_1000);
+        .isEqualTo((byte) 0b0000_1000);
     assertThat(NumberUtils.getLowByteBits(0b0100_0100))
-        .isEqualTo(0b0000_0100);
+        .isEqualTo((byte) 0b0000_0100);
     assertThat(NumberUtils.getLowByteBits(0b0010_0010))
-        .isEqualTo(0b0000_0010);
+        .isEqualTo((byte) 0b0000_0010);
     assertThat(NumberUtils.getLowByteBits(0b0001_0001))
-        .isEqualTo(0b0000_0001);
+        .isEqualTo((byte) 0b0000_0001);
     assertThat(NumberUtils.getLowByteBits(0b0101_0101))
-        .isEqualTo(0b0000_0101);
+        .isEqualTo((byte) 0b0000_0101);
   }
 
   @Test
@@ -227,7 +230,6 @@ class NumberUtilsTest {
 
   @Test
   void shouldValidateIntegerCorrectly() {
-
     // int
     assertThat(NumberUtils.validate(10, 1, 20))
         .isEqualTo(10);
@@ -281,7 +283,6 @@ class NumberUtilsTest {
 
   @Test
   void shouldValidateBooleanCorrectly() {
-
     assertThat(NumberUtils.toBoolean(1)).isTrue();
     assertThat(NumberUtils.toBoolean(0)).isFalse();
     assertThat(NumberUtils.toBoolean(1L)).isTrue();
@@ -307,7 +308,6 @@ class NumberUtilsTest {
 
   @Test
   void shouldEqualsNumbersCorrectly() {
-
     assertThat(NumberUtils.equals((byte) 10, (byte) 10)).isTrue();
     assertThat(NumberUtils.equals((short) 10, (short) 10)).isTrue();
     assertThat(NumberUtils.equals(10, 10)).isTrue();

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/NumberUtilsTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/NumberUtilsTest.java
@@ -1,11 +1,7 @@
 package javasabr.rlib.common.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,94 +14,125 @@ class NumberUtilsTest {
 
   @Test
   void shouldCheckStringIsLong() {
-    assertTrue(NumberUtils.isLong("1"));
-    assertTrue(NumberUtils.isLong("123123213123"));
-    assertFalse(NumberUtils.isLong("notlong"));
-    assertFalse(NumberUtils.isLong(null));
-    assertFalse(NumberUtils.isLong("2.1234"));
+    assertThat(NumberUtils.isLong("1")).isTrue();
+    assertThat(NumberUtils.isLong("123123213123")).isTrue();
+    assertThat(NumberUtils.isLong("notlong")).isFalse();
+    assertThat(NumberUtils.isLong(null)).isFalse();
+    assertThat(NumberUtils.isLong("2.1234")).isFalse();
   }
 
   @Test
   void shouldSafetyConvertStringToLong() {
-    assertNotNull(NumberUtils.safeToLong("1"));
-    assertNotNull(NumberUtils.safeToLong("123123213123"));
-    assertNull(NumberUtils.safeToLong("notlong"));
-    assertNull(NumberUtils.safeToLong(null));
-    assertNull(NumberUtils.safeToLong("2.1234"));
+    assertThat(NumberUtils.safeToLong("1")).isNotNull();
+    assertThat(NumberUtils.safeToLong("123123213123")).isNotNull();
+    assertThat(NumberUtils.safeToLong("notlong")).isNull();
+    assertThat(NumberUtils.safeToLong(null)).isNull();
+    assertThat(NumberUtils.safeToLong("2.1234")).isNull();
   }
 
   @Test
   void shouldConvertStringToOptionalLong() {
-    assertTrue(NumberUtils
+    assertThat(NumberUtils
         .toOptionalLong("1")
-        .isPresent());
-    assertTrue(NumberUtils
+        .isPresent()).isTrue();
+    assertThat(NumberUtils
         .toOptionalLong("123123213123")
-        .isPresent());
-    assertFalse(NumberUtils
+        .isPresent()).isTrue();
+    assertThat(NumberUtils
         .toOptionalLong("notlong")
-        .isPresent());
-    assertFalse(NumberUtils
+        .isPresent()).isFalse();
+    assertThat(NumberUtils
         .toOptionalLong(null)
-        .isPresent());
-    assertFalse(NumberUtils
+        .isPresent()).isFalse();
+    assertThat(NumberUtils
         .toOptionalLong("2.1234")
-        .isPresent());
+        .isPresent()).isFalse();
   }
 
   @Test
   void shouldSafetyConvertStringToInt() {
-    assertNotNull(NumberUtils.safeToInt("1"));
-    assertNotNull(NumberUtils.safeToInt("123124"));
-    assertNull(NumberUtils.safeToInt("notlong"));
-    assertNull(NumberUtils.safeToInt(null));
-    assertNull(NumberUtils.safeToInt("2.1234"));
+    assertThat(NumberUtils.safeToInt("1")).isNotNull();
+    assertThat(NumberUtils.safeToInt("123124")).isNotNull();
+    assertThat(NumberUtils.safeToInt("notlong")).isNull();
+    assertThat(NumberUtils.safeToInt(null)).isNull();
+    assertThat(NumberUtils.safeToInt("2.1234")).isNull();
   }
 
   @Test
   void shouldReadBitsCorrectly() {
+    assertThat(NumberUtils.isSetBit((byte) 0b00000001, 0))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 0))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b00000001, 0));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 0));
+    assertThat(NumberUtils.isSetBit((byte) 0b00000010, 1))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 1))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b00000010, 1));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 1));
+    assertThat(NumberUtils.isSetBit((byte) 0b00000100, 2))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 2))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b00000100, 2));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 2));
+    assertThat(NumberUtils.isSetBit((byte) 0b00001000, 3))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 3))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b00001000, 3));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 3));
+    assertThat(NumberUtils.isSetBit((byte) 0b00010000, 4))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 4))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b00010000, 4));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 4));
+    assertThat(NumberUtils.isSetBit((byte) 0b00100000, 5))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 5))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b00100000, 5));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 5));
+    assertThat(NumberUtils.isSetBit((byte) 0b01000000, 6))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 6))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b01000000, 6));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 6));
+    assertThat(NumberUtils.isSetBit((byte) 0b10000000, 7))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 7))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b10000000, 7));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 7));
+    assertThat(NumberUtils.isSetBit((byte) 0b11111111, 0))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit((byte) 0b11111111, 1))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit((byte) 0b11111111, 2))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit((byte) 0b11111111, 3))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit((byte) 0b11111111, 4))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit((byte) 0b11111111, 5))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit((byte) 0b11111111, 6))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit((byte) 0b11111111, 7))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit((byte) 0b11111111, 0));
-    assertTrue(NumberUtils.isSetBit((byte) 0b11111111, 1));
-    assertTrue(NumberUtils.isSetBit((byte) 0b11111111, 2));
-    assertTrue(NumberUtils.isSetBit((byte) 0b11111111, 3));
-    assertTrue(NumberUtils.isSetBit((byte) 0b11111111, 4));
-    assertTrue(NumberUtils.isSetBit((byte) 0b11111111, 5));
-    assertTrue(NumberUtils.isSetBit((byte) 0b11111111, 6));
-    assertTrue(NumberUtils.isSetBit((byte) 0b11111111, 7));
-
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 0));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 1));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 2));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 3));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 4));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 5));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 6));
-    assertTrue(NumberUtils.isNotSetBit((byte) 0b00000000, 7));
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 0))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 1))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 2))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 3))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 4))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 5))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 6))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit((byte) 0b00000000, 7))
+        .isTrue();
   }
 
   @Test
@@ -114,137 +141,185 @@ class NumberUtilsTest {
     for (int low = 0; low < 16; low++) {
       for (int high = 0; high < 16; high++) {
         var result = NumberUtils.setHighByteBits(low, high);
-        assertEquals(high, NumberUtils.getHighByteBits(result));
-        assertEquals(low, NumberUtils.getLowByteBits(result));
+        assertThat(NumberUtils.getHighByteBits(result)).isEqualTo(high);
+        assertThat(NumberUtils.getLowByteBits(result)).isEqualTo(low);
       }
     }
 
     for (int low = 0; low < 16; low++) {
       var result = NumberUtils.setLowByteBits(256, low);
-      assertEquals(16, NumberUtils.getHighByteBits(result));
-      assertEquals(low, NumberUtils.getLowByteBits(result));
+      assertThat(NumberUtils.getHighByteBits(result)).isEqualTo(16);
+      assertThat(NumberUtils.getLowByteBits(result)).isEqualTo(low);
     }
   }
 
   @Test
   void shouldReadHighLowBitsCorrectly() {
-
     for (int i = 0; i < 16; i++) {
-      assertEquals(i, NumberUtils.getHighByteBits(i << 4));
+      assertThat(NumberUtils.getHighByteBits(i << 4))
+          .isEqualTo(i);
     }
 
-    assertEquals(0b0000_1000, NumberUtils.getHighByteBits(0b1000_0100));
-    assertEquals(0b0000_0100, NumberUtils.getHighByteBits(0b0100_1000));
-    assertEquals(0b0000_0010, NumberUtils.getHighByteBits(0b0010_0010));
-    assertEquals(0b0000_0001, NumberUtils.getHighByteBits(0b0001_0001));
-    assertEquals(0b0000_0101, NumberUtils.getHighByteBits(0b0101_1000));
+    assertThat(NumberUtils.getHighByteBits(0b1000_0100))
+        .isEqualTo(0b0000_1000);
+    assertThat(NumberUtils.getHighByteBits(0b0100_1000))
+        .isEqualTo(0b0000_0100);
+    assertThat(NumberUtils.getHighByteBits(0b0010_0010))
+        .isEqualTo(0b0000_0010);
+    assertThat(NumberUtils.getHighByteBits(0b0001_0001))
+        .isEqualTo(0b0000_0001);
+    assertThat(NumberUtils.getHighByteBits(0b0101_1000))
+        .isEqualTo(0b0000_0101);
 
     for (int i = 0; i < 16; i++) {
-      assertEquals(i, NumberUtils.getLowByteBits(i & 0x0F));
+      assertThat(NumberUtils.getLowByteBits(i & 0x0F))
+          .isEqualTo(i);
     }
 
-    assertEquals(0b0000_1000, NumberUtils.getLowByteBits(0b1000_1000));
-    assertEquals(0b0000_0100, NumberUtils.getLowByteBits(0b0100_0100));
-    assertEquals(0b0000_0010, NumberUtils.getLowByteBits(0b0010_0010));
-    assertEquals(0b0000_0001, NumberUtils.getLowByteBits(0b0001_0001));
-    assertEquals(0b0000_0101, NumberUtils.getLowByteBits(0b0101_0101));
+    assertThat(NumberUtils.getLowByteBits(0b1000_1000))
+        .isEqualTo(0b0000_1000);
+    assertThat(NumberUtils.getLowByteBits(0b0100_0100))
+        .isEqualTo(0b0000_0100);
+    assertThat(NumberUtils.getLowByteBits(0b0010_0010))
+        .isEqualTo(0b0000_0010);
+    assertThat(NumberUtils.getLowByteBits(0b0001_0001))
+        .isEqualTo(0b0000_0001);
+    assertThat(NumberUtils.getLowByteBits(0b0101_0101))
+        .isEqualTo(0b0000_0101);
   }
 
   @Test
   void shouldChangeBitsInByteCorrectly() {
+    assertThat(NumberUtils.isSetBit(NumberUtils.setBit(0, 0), 0))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit(NumberUtils.setBit(0, 1), 1))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit(NumberUtils.setBit(0, 2), 2))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit(NumberUtils.setBit(0, 3), 3))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit(NumberUtils.setBit(0, 4), 4))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit(NumberUtils.setBit(0, 5), 5))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit(NumberUtils.setBit(0, 6), 6))
+        .isTrue();
+    assertThat(NumberUtils.isSetBit(NumberUtils.setBit(0, 7), 7))
+        .isTrue();
 
-    assertTrue(NumberUtils.isSetBit(NumberUtils.setBit(0, 0), 0));
-    assertTrue(NumberUtils.isSetBit(NumberUtils.setBit(0, 1), 1));
-    assertTrue(NumberUtils.isSetBit(NumberUtils.setBit(0, 2), 2));
-    assertTrue(NumberUtils.isSetBit(NumberUtils.setBit(0, 3), 3));
-    assertTrue(NumberUtils.isSetBit(NumberUtils.setBit(0, 4), 4));
-    assertTrue(NumberUtils.isSetBit(NumberUtils.setBit(0, 5), 5));
-    assertTrue(NumberUtils.isSetBit(NumberUtils.setBit(0, 6), 6));
-    assertTrue(NumberUtils.isSetBit(NumberUtils.setBit(0, 7), 7));
-
-    assertTrue(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 0), 0));
-    assertTrue(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 1), 1));
-    assertTrue(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 2), 2));
-    assertTrue(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 3), 3));
-    assertTrue(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 4), 4));
-    assertTrue(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 5), 5));
-    assertTrue(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 6), 6));
-    assertTrue(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 7), 7));
+    assertThat(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 0), 0))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 1), 1))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 2), 2))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 3), 3))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 4), 4))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 5), 5))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 6), 6))
+        .isTrue();
+    assertThat(NumberUtils.isNotSetBit(NumberUtils.unsetBit(255, 7), 7))
+        .isTrue();
   }
 
   @Test
   void shouldValidateIntegerCorrectly() {
 
     // int
-    assertEquals(10, NumberUtils.validate(10, 1, 20));
-    assertEquals(-20, NumberUtils.validate(-20, -21, 10));
-    assertEquals(-1000, NumberUtils.validate(-1000, -1050, -1000));
+    assertThat(NumberUtils.validate(10, 1, 20))
+        .isEqualTo(10);
+    assertThat(NumberUtils.validate(-20, -21, 10))
+        .isEqualTo(-20);
+    assertThat(NumberUtils.validate(-1000, -1050, -1000))
+        .isEqualTo(-1000);
 
-    assertEquals(10, NumberUtils.validate(10, 1, 20, IllegalArgumentException::new));
-    assertEquals(-20, NumberUtils.validate(-20, -21, 10, IllegalArgumentException::new));
-    assertEquals(-1000, NumberUtils.validate(-1000, -1050, -1000, IllegalArgumentException::new));
+    assertThat(NumberUtils.validate(10, 1, 20, IllegalArgumentException::new))
+        .isEqualTo(10);
+    assertThat(NumberUtils.validate(-20, -21, 10, IllegalArgumentException::new))
+        .isEqualTo(-20);
+    assertThat(NumberUtils.validate(-1000, -1050, -1000, IllegalArgumentException::new))
+        .isEqualTo(-1000);
 
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.validate(10, 20, 50, IllegalArgumentException::new));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> NumberUtils.validate(-50, -70, -51, IllegalArgumentException::new));
+    assertThatThrownBy(() -> NumberUtils.validate(10, 20, 50, IllegalArgumentException::new))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> NumberUtils.validate(-50, -70, -51, IllegalArgumentException::new))
+        .isInstanceOf(IllegalArgumentException.class);
 
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.validate(10, 20, 50));
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.validate(-50, -70, -51));
+    assertThatThrownBy(() -> NumberUtils.validate(10, 20, 50))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> NumberUtils.validate(-50, -70, -51))
+        .isInstanceOf(IllegalArgumentException.class);
 
     // long
-    assertEquals(10, NumberUtils.validate(10L, 1, 20));
-    assertEquals(-20, NumberUtils.validate(-20L, -21, 10));
-    assertEquals(-1000, NumberUtils.validate(-1000L, -1050, -1000));
+    assertThat(NumberUtils.validate(10L, 1, 20))
+        .isEqualTo(10);
+    assertThat(NumberUtils.validate(-20L, -21, 10))
+        .isEqualTo(-20);
+    assertThat(NumberUtils.validate(-1000L, -1050, -1000))
+        .isEqualTo(-1000);
 
-    assertEquals(10, NumberUtils.validate(10L, 1, 20, IllegalArgumentException::new));
-    assertEquals(-20, NumberUtils.validate(-20L, -21, 10, IllegalArgumentException::new));
-    assertEquals(-1000, NumberUtils.validate(-1000L, -1050, -1000, IllegalArgumentException::new));
+    assertThat(NumberUtils.validate(10L, 1, 20, IllegalArgumentException::new))
+        .isEqualTo(10);
+    assertThat(NumberUtils.validate(-20L, -21, 10, IllegalArgumentException::new))
+        .isEqualTo(-20);
+    assertThat(NumberUtils.validate(-1000L, -1050, -1000, IllegalArgumentException::new))
+        .isEqualTo(-1000);
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> NumberUtils.validate(10L, 20, 50, IllegalArgumentException::new));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> NumberUtils.validate(-50L, -70, -51, IllegalArgumentException::new));
+    assertThatThrownBy(() -> NumberUtils.validate(10L, 20, 50, IllegalArgumentException::new))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> NumberUtils.validate(-50L, -70, -51, IllegalArgumentException::new))
+        .isInstanceOf(IllegalArgumentException.class);
 
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.validate(10L, 20, 50));
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.validate(-50L, -70, -51));
+    assertThatThrownBy(() -> NumberUtils.validate(10L, 20, 50))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> NumberUtils.validate(-50L, -70, -51))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void shouldValidateBooleanCorrectly() {
 
-    assertTrue(NumberUtils.toBoolean(1));
-    assertFalse(NumberUtils.toBoolean(0));
-    assertTrue(NumberUtils.toBoolean(1L));
-    assertFalse(NumberUtils.toBoolean(0L));
-    assertTrue(NumberUtils.toBoolean(1, IllegalArgumentException::new));
-    assertFalse(NumberUtils.toBoolean(0, IllegalArgumentException::new));
-    assertTrue(NumberUtils.toBoolean(1L, IllegalArgumentException::new));
-    assertFalse(NumberUtils.toBoolean(0L, IllegalArgumentException::new));
+    assertThat(NumberUtils.toBoolean(1)).isTrue();
+    assertThat(NumberUtils.toBoolean(0)).isFalse();
+    assertThat(NumberUtils.toBoolean(1L)).isTrue();
+    assertThat(NumberUtils.toBoolean(0L)).isFalse();
+    assertThat(NumberUtils.toBoolean(1, IllegalArgumentException::new))
+        .isTrue();
+    assertThat(NumberUtils.toBoolean(0, IllegalArgumentException::new))
+        .isFalse();
+    assertThat(NumberUtils.toBoolean(1L, IllegalArgumentException::new))
+        .isTrue();
+    assertThat(NumberUtils.toBoolean(0L, IllegalArgumentException::new))
+        .isFalse();
 
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.toBoolean(2));
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.toBoolean(-1));
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.toBoolean(2L));
-    assertThrows(IllegalArgumentException.class, () -> NumberUtils.toBoolean(-1L));
+    assertThatThrownBy(() -> NumberUtils.toBoolean(2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> NumberUtils.toBoolean(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> NumberUtils.toBoolean(2L))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> NumberUtils.toBoolean(-1L))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void shouldEqualsNumbersCorrectly() {
 
-    assertTrue(NumberUtils.equals((byte) 10, (byte) 10));
-    assertTrue(NumberUtils.equals((short) 10, (short) 10));
-    assertTrue(NumberUtils.equals(10, 10));
-    assertTrue(NumberUtils.equals(10L, 10L));
-    assertTrue(NumberUtils.equals(10F, 10F));
-    assertTrue(NumberUtils.equals(10D, 10D));
+    assertThat(NumberUtils.equals((byte) 10, (byte) 10)).isTrue();
+    assertThat(NumberUtils.equals((short) 10, (short) 10)).isTrue();
+    assertThat(NumberUtils.equals(10, 10)).isTrue();
+    assertThat(NumberUtils.equals(10L, 10L)).isTrue();
+    assertThat(NumberUtils.equals(10F, 10F)).isTrue();
+    assertThat(NumberUtils.equals(10D, 10D)).isTrue();
 
-    assertFalse(NumberUtils.equals((byte) -10, (byte) 10));
-    assertFalse(NumberUtils.equals((short) -10, (short) 10));
-    assertFalse(NumberUtils.equals(-10, 10));
-    assertFalse(NumberUtils.equals(-10L, 10L));
-    assertFalse(NumberUtils.equals(-10F, 10F));
-    assertFalse(NumberUtils.equals(-10D, 10D));
+    assertThat(NumberUtils.equals((byte) -10, (byte) 10)).isFalse();
+    assertThat(NumberUtils.equals((short) -10, (short) 10)).isFalse();
+    assertThat(NumberUtils.equals(-10, 10)).isFalse();
+    assertThat(NumberUtils.equals(-10L, 10L)).isFalse();
+    assertThat(NumberUtils.equals(-10F, 10F)).isFalse();
+    assertThat(NumberUtils.equals(-10D, 10D)).isFalse();
   }
 }

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/ReflectionUtilsTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/ReflectionUtilsTest.java
@@ -1,7 +1,6 @@
 package javasabr.rlib.common.util;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,127 +29,142 @@ public class ReflectionUtilsTest {
 
   @Test
   void getAllDeclaredFieldsTest() {
-
     var allFields = ReflectionUtils.getAllDeclaredFields(Type1.class);
 
-    assertNotNull(allFields
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field1"))
         .findAny()
-        .orElse(null));
-    assertNotNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field2"))
         .findAny()
-        .orElse(null));
-    assertNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field3"))
         .findAny()
-        .orElse(null));
+        .orElse(null))
+        .isNull();
 
     allFields = ReflectionUtils.getAllDeclaredFields(Type2.class);
 
-    assertNotNull(allFields
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field1"))
         .findAny()
-        .orElse(null));
-    assertNotNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field2"))
         .findAny()
-        .orElse(null));
-    assertNotNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field3"))
         .findAny()
-        .orElse(null));
-    assertNotNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field4"))
         .findAny()
-        .orElse(null));
-    assertNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field5"))
         .findAny()
-        .orElse(null));
+        .orElse(null))
+        .isNull();
 
     allFields = ReflectionUtils.getAllDeclaredFields(Type1.Inner1.class);
 
-    assertNotNull(allFields
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field1"))
         .findAny()
-        .orElse(null));
-    assertNotNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
-            .equals("field2")));
-    assertNull(allFields
+            .equals("field2")))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field3"))
         .findAny()
-        .orElse(null));
+        .orElse(null))
+        .isNull();
 
     allFields = ReflectionUtils.getAllDeclaredFields(Type1.Inner2.class);
 
-    assertNotNull(allFields
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field1"))
         .findAny()
-        .orElse(null));
-    assertNotNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field2"))
         .findAny()
-        .orElse(null));
-    assertNotNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field3"))
         .findAny()
-        .orElse(null));
-    assertNotNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field4"))
         .findAny()
-        .orElse(null));
-    assertNull(allFields
+        .orElse(null))
+        .isNotNull();
+    assertThat(allFields
         .stream()
         .filter(object -> object
             .getName()
             .equals("field5"))
         .findAny()
-        .orElse(null));
+        .orElse(null))
+        .isNull();
   }
 }

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/StringUtilsTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/StringUtilsTest.java
@@ -1,6 +1,8 @@
 package javasabr.rlib.common.util;
 
-import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -17,7 +19,7 @@ class StringUtilsTest {
     var hex = StringUtils.toHex(original);
     var parsed = StringUtils.fromHex(hex);
 
-    Assertions.assertEquals(original, parsed);
+    assertThat(parsed).isEqualTo(original);
   }
 
   @Test
@@ -37,7 +39,7 @@ class StringUtilsTest {
     var hex = StringUtils.bytesToHexString(original);
     var parsed = StringUtils.hexStringToBytes(hex);
 
-    Assertions.assertArrayEquals(original, parsed);
+    assertThat(parsed).isEqualTo(original);
   }
 
   @Test
@@ -46,7 +48,8 @@ class StringUtilsTest {
     var original = "some text ${test_var} with one variable";
     var expected = "some text var_val with one variable";
 
-    Assertions.assertEquals(expected, StringUtils.replace(original, "${test_var}", "var_val"));
+    assertThat(StringUtils.replace(original, "${test_var}", "var_val"))
+        .isEqualTo(expected);
   }
 
   @Test
@@ -55,9 +58,8 @@ class StringUtilsTest {
     var original = "some text ${test_var1} with two variable ${test_var2}";
     var expected = "some text var_val_1 with two variable var_val_2";
 
-    Assertions.assertEquals(
-        expected,
-        StringUtils.replace(original, "${test_var1}", "var_val_1", "${test_var2}", "var_val_2"));
+    assertThat(StringUtils.replace(original, "${test_var1}", "var_val_1", "${test_var2}", "var_val_2"))
+        .isEqualTo(expected);
   }
 
   @Test
@@ -66,9 +68,8 @@ class StringUtilsTest {
     var original = "some text ${test_var1} with two variable ${test_var2}, and ${test_var1} and ${test_var2}";
     var expected = "some text var_val_1 with two variable var_val_2, and var_val_1 and var_val_2";
 
-    Assertions.assertEquals(
-        expected,
-        StringUtils.replace(original, "${test_var1}", "var_val_1", "${test_var2}", "var_val_2"));
+    assertThat(StringUtils.replace(original, "${test_var1}", "var_val_1", "${test_var2}", "var_val_2"))
+        .isEqualTo(expected);
   }
 
   @Test
@@ -77,105 +78,105 @@ class StringUtilsTest {
     var original = "some text ${test_var1} with variables ${test_var2}, ${test_var3}";
     var expected = "some text var_val_1 with variables var_val_2, var_val_3";
 
-    Assertions.assertEquals(
-        expected,
-        StringUtils.replace(
+    assertThat(StringUtils.replace(
             original,
             "${test_var1}",
             "var_val_1",
             "${test_var2}",
             "var_val_2",
             "${test_var3}",
-            "var_val_3"));
+            "var_val_3"))
+        .isEqualTo(expected);
   }
 
   @Test
   void shouldThrownIllegalArgumentExceptionDuringReplacingStringWithWrongArgs() {
 
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> StringUtils.replace("string", "name1", "val1", "name2"));
+    assertThatThrownBy(() -> StringUtils.replace("string", "name1", "val1", "name2"))
+        .isInstanceOf(IllegalArgumentException.class);
 
-    Assertions.assertThrows(IllegalArgumentException.class, () -> StringUtils.replace("string", "name1"));
+    assertThatThrownBy(() -> StringUtils.replace("string", "name1"))
+        .isInstanceOf(IllegalArgumentException.class);
 
-    Assertions.assertThrows(IllegalArgumentException.class, () -> StringUtils.replace("string"));
+    assertThatThrownBy(() -> StringUtils.replace("string"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void shouldVerifyEmails() {
-    Assertions.assertTrue(StringUtils.isValidEmail("test@test.com"));
-    Assertions.assertTrue(StringUtils.isValidEmail("тест@test.com"));
-    Assertions.assertTrue(StringUtils.isValidEmail("тест@тест.рф"));
-    Assertions.assertTrue(StringUtils.isValidEmail("my-name.test@test.com"));
+    assertThat(StringUtils.isValidEmail("test@test.com")).isTrue();
+    assertThat(StringUtils.isValidEmail("тест@test.com")).isTrue();
+    assertThat(StringUtils.isValidEmail("тест@тест.рф")).isTrue();
+    assertThat(StringUtils.isValidEmail("my-name.test@test.com")).isTrue();
 
-    Assertions.assertFalse(StringUtils.isValidEmail("@test.com"));
-    Assertions.assertFalse(StringUtils.isValidEmail("test@.com"));
-    Assertions.assertFalse(StringUtils.isValidEmail("%$%&$&%@$%&&%$&.com"));
+    assertThat(StringUtils.isValidEmail("@test.com")).isFalse();
+    assertThat(StringUtils.isValidEmail("test@.com")).isFalse();
+    assertThat(StringUtils.isValidEmail("%$%&$&%@$%&&%$&.com")).isFalse();
   }
 
   @Test
   void shouldDetectEmails() {
-    Assertions.assertTrue(StringUtils.isEmail("test@test.com"));
-    Assertions.assertTrue(StringUtils.isEmail("test.test@test.com"));
-    Assertions.assertTrue(StringUtils.isEmail("test.test@test.test.com"));
+    assertThat(StringUtils.isEmail("test@test.com")).isTrue();
+    assertThat(StringUtils.isEmail("test.test@test.com")).isTrue();
+    assertThat(StringUtils.isEmail("test.test@test.test.com")).isTrue();
 
-    Assertions.assertFalse(StringUtils.isEmail("@test.com"));
-    Assertions.assertFalse(StringUtils.isEmail("test-test.com"));
-    Assertions.assertFalse(StringUtils.isEmail("test@test"));
-    Assertions.assertFalse(StringUtils.isEmail("test@test."));
+    assertThat(StringUtils.isEmail("@test.com")).isFalse();
+    assertThat(StringUtils.isEmail("test-test.com")).isFalse();
+    assertThat(StringUtils.isEmail("test@test")).isFalse();
+    assertThat(StringUtils.isEmail("test@test.")).isFalse();
   }
 
   @Test
   void shouldCheckIfStringIsEmpty() {
-    Assertions.assertTrue(StringUtils.isEmpty(null));
-    Assertions.assertFalse(StringUtils.isNotEmpty(null));
+    assertThat(StringUtils.isEmpty(null)).isTrue();
+    assertThat(StringUtils.isNotEmpty(null)).isFalse();
     
-    Assertions.assertTrue(StringUtils.isEmpty(""));
-    Assertions.assertFalse(StringUtils.isNotEmpty(""));
+    assertThat(StringUtils.isEmpty("")).isTrue();
+    assertThat(StringUtils.isNotEmpty("")).isFalse();
     
-    Assertions.assertFalse(StringUtils.isEmpty(" "));
-    Assertions.assertTrue(StringUtils.isNotEmpty(" "));
+    assertThat(StringUtils.isEmpty(" ")).isFalse();
+    assertThat(StringUtils.isNotEmpty(" ")).isTrue();
     
-    Assertions.assertFalse(StringUtils.isEmpty("123"));
-    Assertions.assertTrue(StringUtils.isNotEmpty("123"));
+    assertThat(StringUtils.isEmpty("123")).isFalse();
+    assertThat(StringUtils.isNotEmpty("123")).isTrue();
   }
 
   @Test
   void shouldReturnAnotherStringIfEmpty() {
-    Assertions.assertEquals("alt", StringUtils.ifEmpty(null, "alt"));
-    Assertions.assertEquals("alt", StringUtils.ifEmpty("", "alt"));
-    Assertions.assertEquals(" ", StringUtils.ifEmpty(" ", "alt"));
-    Assertions.assertEquals("123", StringUtils.ifEmpty("123", "alt"));
+    assertThat(StringUtils.ifEmpty(null, "alt")).isEqualTo("alt");
+    assertThat(StringUtils.ifEmpty("", "alt")).isEqualTo("alt");
+    assertThat(StringUtils.ifEmpty(" ", "alt")).isEqualTo(" ");
+    assertThat(StringUtils.ifEmpty("123", "alt")).isEqualTo("123");
   }
 
   @Test
   void shouldCheckIfStringIsBlank() {
-    Assertions.assertTrue(StringUtils.isBlank(null));
-    Assertions.assertFalse(StringUtils.isNotBlank(null));
+    assertThat(StringUtils.isBlank(null)).isTrue();
+    assertThat(StringUtils.isNotBlank(null)).isFalse();
     
-    Assertions.assertTrue(StringUtils.isBlank(""));
-    Assertions.assertFalse(StringUtils.isNotBlank(""));
+    assertThat(StringUtils.isBlank("")).isTrue();
+    assertThat(StringUtils.isNotBlank("")).isFalse();
     
-    Assertions.assertTrue(StringUtils.isBlank(" "));
-    Assertions.assertFalse(StringUtils.isNotBlank(" "));
+    assertThat(StringUtils.isBlank(" ")).isTrue();
+    assertThat(StringUtils.isNotBlank(" ")).isFalse();
     
-    Assertions.assertTrue(StringUtils.isBlank("       "));
-    Assertions.assertFalse(StringUtils.isNotBlank("       "));
+    assertThat(StringUtils.isBlank("       ")).isTrue();
+    assertThat(StringUtils.isNotBlank("       ")).isFalse();
     
-    Assertions.assertFalse(StringUtils.isBlank("   1"));
-    Assertions.assertTrue(StringUtils.isNotBlank("   1"));
+    assertThat(StringUtils.isBlank("   1")).isFalse();
+    assertThat(StringUtils.isNotBlank("   1")).isTrue();
     
-    Assertions.assertFalse(StringUtils.isBlank("123"));
-    Assertions.assertTrue(StringUtils.isNotBlank("123"));
+    assertThat(StringUtils.isBlank("123")).isFalse();
+    assertThat(StringUtils.isNotBlank("123")).isTrue();
   }
   
   @Test
   void shouldReturnAnotherStringIfBlank() {
-    Assertions.assertEquals("alt", StringUtils.ifBlank(null, "alt"));
-    Assertions.assertEquals("alt", StringUtils.ifBlank("", "alt"));
-    Assertions.assertEquals("alt", StringUtils.ifBlank(" ", "alt"));
-    Assertions.assertEquals("alt", StringUtils.ifBlank("   ", "alt"));
-    Assertions.assertEquals("    1", StringUtils.ifBlank("    1", "alt"));
-    Assertions.assertEquals("123", StringUtils.ifBlank("123", "alt"));
+    assertThat(StringUtils.ifBlank(null, "alt")).isEqualTo("alt");
+    assertThat(StringUtils.ifBlank("", "alt")).isEqualTo("alt");
+    assertThat(StringUtils.ifBlank(" ", "alt")).isEqualTo("alt");
+    assertThat(StringUtils.ifBlank("   ", "alt")).isEqualTo("alt");
+    assertThat(StringUtils.ifBlank("    1", "alt")).isEqualTo("    1");
+    assertThat(StringUtils.ifBlank("123", "alt")).isEqualTo("123");
   }
 }

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/UtilsTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/UtilsTest.java
@@ -1,6 +1,7 @@
 package javasabr.rlib.common.util;
 
-import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -12,17 +13,22 @@ public class UtilsTest {
 
   @Test
   void shouldSafetyTryGet() {
+    assertThat(Utils.tryGet("15", Integer::valueOf))
+        .isEqualTo(Integer.valueOf(15));
+    assertThat(Utils.tryGet("invalidnumber", Integer::valueOf))
+        .isNull();
 
-    Assertions.assertEquals(Integer.valueOf(15), Utils.tryGet("15", Integer::valueOf));
-    Assertions.assertNull(Utils.tryGet("invalidnumber", Integer::valueOf));
-
-    Assertions.assertEquals(Integer.valueOf(15), Utils.tryGet("15", Integer::valueOf, 2));
-    Assertions.assertEquals(Integer.valueOf(2), Utils.tryGet("invalidnumber", Integer::valueOf, 2));
+    assertThat(Utils.tryGet("15", Integer::valueOf, 2))
+        .isEqualTo(Integer.valueOf(15));
+    assertThat(Utils.tryGet("invalidnumber", Integer::valueOf, 2))
+        .isEqualTo(Integer.valueOf(2));
   }
 
   @Test
   void shouldSafetyTryGetAndConvert() {
-    Assertions.assertEquals("15", Utils.tryGetAndConvert("15", Integer::valueOf, Object::toString));
-    Assertions.assertNull(Utils.tryGetAndConvert("invalidnumber", Integer::valueOf, Object::toString));
+    assertThat(Utils.tryGetAndConvert("15", Integer::valueOf, Object::toString))
+        .isEqualTo("15");
+    assertThat(Utils.tryGetAndConvert("invalidnumber", Integer::valueOf, Object::toString))
+        .isNull();
   }
 }

--- a/rlib-common/src/test/java/javasabr/rlib/common/util/UtilsTest.java
+++ b/rlib-common/src/test/java/javasabr/rlib/common/util/UtilsTest.java
@@ -13,11 +13,15 @@ public class UtilsTest {
 
   @Test
   void shouldSafetyTryGet() {
-    assertThat(Utils.tryGet("15", Integer::valueOf))
-        .isEqualTo(Integer.valueOf(15));
-    assertThat(Utils.tryGet("invalidnumber", Integer::valueOf))
-        .isNull();
+    // when/then:
+    Integer number = Utils.tryGet("15", Integer::valueOf);
+    assertThat(number).isEqualTo(Integer.valueOf(15));
 
+    // when/then:
+    Integer invalidNumber = Utils.tryGet("invalidnumber", Integer::valueOf);
+    assertThat(invalidNumber).isNull();
+    
+    // when/then:
     assertThat(Utils.tryGet("15", Integer::valueOf, 2))
         .isEqualTo(Integer.valueOf(15));
     assertThat(Utils.tryGet("invalidnumber", Integer::valueOf, 2))

--- a/rlib-compiler/src/test/java/javasabr/rlib/compiler/CompilerTests.java
+++ b/rlib-compiler/src/test/java/javasabr/rlib/compiler/CompilerTests.java
@@ -1,5 +1,7 @@
 package javasabr.rlib.compiler;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
 import java.net.URISyntaxException;
@@ -9,7 +11,6 @@ import javasabr.rlib.collections.array.ArrayCollectors;
 import javasabr.rlib.common.util.ClassUtils;
 import javasabr.rlib.logger.api.LoggerLevel;
 import javasabr.rlib.logger.api.LoggerManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,11 +41,14 @@ public class CompilerTests {
         .collect(ArrayCollectors.toArray(Class.class));
 
     // then:
-    Assertions.assertEquals(3, compiledClasses.size());
+    assertThat(compiledClasses.size()).isEqualTo(3);
 
-    Assertions.assertEquals("TestCompileDependency", compiledClasses.get(0).getName());
-    Assertions.assertEquals("TestCompileJavaSource", compiledClasses.get(1).getName());
-    Assertions.assertEquals("TestCompileRecord", compiledClasses.get(2).getName());
+    assertThat(compiledClasses.get(0).getName())
+        .isEqualTo("TestCompileDependency");
+    assertThat(compiledClasses.get(1).getName())
+        .isEqualTo("TestCompileJavaSource");
+    assertThat(compiledClasses.get(2).getName())
+        .isEqualTo("TestCompileRecord");
 
     // when:
     var instance1 = ClassUtils.newInstance(compiledClasses.get(0));
@@ -54,7 +58,7 @@ public class CompilerTests {
     var result = method.invoke(instance1);
 
     // then:
-    Assertions.assertEquals(5, result);
+    assertThat(result).isEqualTo(5);
 
     // when:
     var instance2 = ClassUtils.newInstance(compiledClasses.get(1));
@@ -64,7 +68,7 @@ public class CompilerTests {
     result = method.invoke(instance2);
 
     // then:
-    Assertions.assertEquals("testString", result);
+    assertThat(result).isEqualTo("testString");
 
     // when:
     Record instance3 = (Record) ClassUtils
@@ -76,7 +80,9 @@ public class CompilerTests {
         .getClass()
         .getRecordComponents();
 
-    Assertions.assertEquals(instance1, recordComponents[0].getAccessor().invoke(instance3));
-    Assertions.assertEquals("recordString", recordComponents[1].getAccessor().invoke(instance3));
+    assertThat(recordComponents[0].getAccessor().invoke(instance3))
+        .isEqualTo(instance1);
+    assertThat(recordComponents[1].getAccessor().invoke(instance3))
+        .isEqualTo("recordString");
   }
 }

--- a/rlib-concurrent/src/test/java/javasabr/rlib/concurrent/executor/TestThreadPoolTaskExecutor.java
+++ b/rlib-concurrent/src/test/java/javasabr/rlib/concurrent/executor/TestThreadPoolTaskExecutor.java
@@ -1,10 +1,11 @@
 package javasabr.rlib.concurrent.executor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.concurrent.atomic.AtomicInteger;
 import javasabr.rlib.common.util.GroupThreadFactory;
 import javasabr.rlib.common.util.ThreadUtils;
 import javasabr.rlib.concurrent.executor.impl.ThreadPoolTaskExecutor;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * @author JavaSaBr
@@ -33,7 +34,7 @@ public class TestThreadPoolTaskExecutor {
 
     ThreadUtils.sleep(30);
 
-    Assertions.assertEquals(TASK_LIMIT, counter.get());
+    assertThat(counter.get()).isEqualTo(TASK_LIMIT);
 
     System.out.println(header + " test executor finished.");
   }

--- a/rlib-geometry/src/test/java/javasabr/rlib/geometry/QuaternionTests.java
+++ b/rlib-geometry/src/test/java/javasabr/rlib/geometry/QuaternionTests.java
@@ -1,6 +1,7 @@
 package javasabr.rlib.geometry;
 
-import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,21 +27,27 @@ public class QuaternionTests {
 
     var side = quaternion.getDirection(DirectionType.FRONT);
 
-    Assertions.assertTrue(originForward.equals(side, 0.001f));
+    assertThat(originForward.equals(side, 0.001f))
+        .isTrue();
 
     quaternion.getDirection(DirectionType.BEHIND, side);
-    Assertions.assertTrue(originBackward.equals(side, 0.001f));
+    assertThat(originBackward.equals(side, 0.001f))
+        .isTrue();
 
     quaternion.getDirection(DirectionType.RIGHT, side);
-    Assertions.assertTrue(originRight.equals(side, 0.001f));
+    assertThat(originRight.equals(side, 0.001f))
+        .isTrue();
 
     quaternion.getDirection(DirectionType.LEFT, side);
-    Assertions.assertTrue(originLeft.equals(side, 0.001f));
+    assertThat(originLeft.equals(side, 0.001f))
+        .isTrue();
 
     quaternion.getDirection(DirectionType.UP, side);
-    Assertions.assertTrue(originUp.equals(side, 0.001f));
+    assertThat(originUp.equals(side, 0.001f))
+        .isTrue();
 
     quaternion.getDirection(DirectionType.DOWN, side);
-    Assertions.assertTrue(originDown.equals(side, 0.001f));
+    assertThat(originDown.equals(side, 0.001f))
+        .isTrue();
   }
 }

--- a/rlib-io/src/test/java/javasabr/rlib/io/FileUtilsTest.java
+++ b/rlib-io/src/test/java/javasabr/rlib/io/FileUtilsTest.java
@@ -1,12 +1,8 @@
 package javasabr.rlib.io;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javasabr.rlib.io.util.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -16,33 +12,34 @@ public class FileUtilsTest {
 
   @Test
   void shouldGetNameByPath() {
-
     var path = "/some/folder/some/name.ololo";
     var path2 = "D:\\some\\folder\\some\\name.ololo";
 
-    Assertions.assertEquals("name.ololo", FileUtils.getName(path, '/'));
-    assertEquals("name.ololo", FileUtils.getName(path2, '\\'));
+    assertThat(FileUtils.getName(path, '/'))
+        .isEqualTo("name.ololo");
+    assertThat(FileUtils.getName(path2, '\\'))
+        .isEqualTo("name.ololo");
   }
 
   @Test
   void shouldGetParentByPath() {
-
     var path = "/some/folder/some/name.ololo";
     var path2 = "D:\\some\\folder\\some\\name.ololo";
 
-    assertEquals("/some/folder/some", FileUtils.getParent(path, '/'));
-    assertEquals("D:\\some\\folder\\some", FileUtils.getParent(path2, '\\'));
+    assertThat(FileUtils.getParent(path, '/'))
+        .isEqualTo("/some/folder/some");
+    assertThat(FileUtils.getParent(path2, '\\'))
+        .isEqualTo("D:\\some\\folder\\some");
   }
 
   @Test
   void shouldNormalizeFileName() {
     var first = FileUtils.normalizeName("file*:?name!!@#$\"\"wefwef<>.png");
-    assertEquals("file___name!!@#$__wefwef__.png", first);
+    assertThat(first).isEqualTo("file___name!!@#$__wefwef__.png");
   }
 
   @Test
   void shouldGetFileExtension() {
-
     var path1 = "file.txt";
     var path2 = "file.tar.gz";
     var path3 = "folder/folder.subname/file.png";
@@ -51,19 +48,18 @@ public class FileUtilsTest {
     var path6 = "D:\\folder\\folder.folder\\test";
     var path7 = "/folder/folder.folder/test";
 
-    assertEquals("txt", FileUtils.getExtension(path1));
-    assertEquals("gz", FileUtils.getExtension(path2));
-    assertEquals("png", FileUtils.getExtension(path3));
-    assertEquals("jpg", FileUtils.getExtension(path4));
-    assertEquals("TxT", FileUtils.getExtension(path5));
-    assertEquals("txt", FileUtils.getExtension(path5, true));
-    assertNull(FileUtils.getExtension(path6));
-    assertNull(FileUtils.getExtension(path7));
+    assertThat(FileUtils.getExtension(path1)).isEqualTo("txt");
+    assertThat(FileUtils.getExtension(path2)).isEqualTo("gz");
+    assertThat(FileUtils.getExtension(path3)).isEqualTo("png");
+    assertThat(FileUtils.getExtension(path4)).isEqualTo("jpg");
+    assertThat(FileUtils.getExtension(path5)).isEqualTo("TxT");
+    assertThat(FileUtils.getExtension(path5, true)).isEqualTo("txt");
+    assertThat(FileUtils.getExtension(path6)).isNull();
+    assertThat(FileUtils.getExtension(path7)).isNull();
   }
 
   @Test
   void shouldCheckExistingExtension() {
-
     var path1 = "file.txt";
     var path2 = "file.tar.gz";
     var path3 = "folder/folder.subname/file.png";
@@ -71,11 +67,11 @@ public class FileUtilsTest {
     var path6 = "D:\\folder\\folder.folder\\test";
     var path7 = "/folder/folder.folder/test";
 
-    assertTrue(FileUtils.hasExtension(path1));
-    assertTrue(FileUtils.hasExtension(path2));
-    assertTrue(FileUtils.hasExtension(path3));
-    assertTrue(FileUtils.hasExtension(path4));
-    assertFalse(FileUtils.hasExtension(path6));
-    assertFalse(FileUtils.hasExtension(path7));
+    assertThat(FileUtils.hasExtension(path1)).isTrue();
+    assertThat(FileUtils.hasExtension(path2)).isTrue();
+    assertThat(FileUtils.hasExtension(path3)).isTrue();
+    assertThat(FileUtils.hasExtension(path4)).isTrue();
+    assertThat(FileUtils.hasExtension(path6)).isFalse();
+    assertThat(FileUtils.hasExtension(path7)).isFalse();
   }
 }

--- a/rlib-io/src/test/java/javasabr/rlib/io/IoUtilsTest.java
+++ b/rlib-io/src/test/java/javasabr/rlib/io/IoUtilsTest.java
@@ -1,5 +1,8 @@
 package javasabr.rlib.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,7 +12,6 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import javasabr.rlib.common.util.StringUtils;
 import javasabr.rlib.io.util.IoUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -19,71 +21,64 @@ class IoUtilsTest {
 
   @Test
   void shouldConvertInputStreamToString() {
-
     var original = StringUtils.generate(2048);
     var source = new ByteArrayInputStream(original.getBytes(StandardCharsets.UTF_8));
 
-    Assertions.assertEquals(original, IoUtils.toString(source), "result string should be the same");
+    assertThat(IoUtils.toString(source))
+        .as("result string should be the same")
+        .isEqualTo(original);
   }
 
   @Test
   void shouldConvertSupplierOfInputStreamToString() {
-
     var original = StringUtils.generate(2048);
-
-    Assertions.assertEquals(
-        original,
-        IoUtils.toString(() -> new ByteArrayInputStream(original.getBytes(StandardCharsets.UTF_8))),
-        "result string should be the same");
+    assertThat(IoUtils.toString(() -> new ByteArrayInputStream(original.getBytes(StandardCharsets.UTF_8))))
+        .as("result string should be the same")
+        .isEqualTo(original);
   }
 
   @Test
   void shouldThrowUncheckedIOExceptionDuringConvertingInputStreamToString() {
-    Assertions.assertThrows(
-        UncheckedIOException.class, () -> IoUtils.toString(new InputStream() {
+    assertThatThrownBy(() -> IoUtils.toString(new InputStream() {
 
           @Override
           public int read() throws IOException {
             throw new IOException("test");
           }
-        }));
+        }))
+        .isInstanceOf(UncheckedIOException.class);
   }
 
   @Test
   void shouldThrowUncheckedIOExceptionDuringConvertingSupplierOfInputStreamToString() {
-    Assertions.assertThrows(
-        UncheckedIOException.class, () -> IoUtils.toString(() -> new InputStream() {
+    assertThatThrownBy(() -> IoUtils.toString(() -> new InputStream() {
 
           @Override
           public int read() throws IOException {
             throw new IOException("test");
           }
-        }));
+        }))
+        .isInstanceOf(UncheckedIOException.class);
   }
 
   @Test
   void shouldThrowRuntimeExceptionDuringConvertingSupplierOfInputStreamToString() {
-    Assertions.assertThrows(
-        RuntimeException.class, () -> {
-          IoUtils.toString(() -> {
-            throw new RuntimeException("test");
-          });
-        });
+    assertThatThrownBy(() -> IoUtils.toString(() -> {
+          throw new RuntimeException("test");
+        }))
+        .isInstanceOf(RuntimeException.class);
   }
 
   @Test
   void shouldConvertReaderToStrungUsingTLB() {
-
     var original = StringUtils.generate(2048);
-
-    Assertions.assertEquals(original, IoUtils.toStringUsingTlb(new StringReader(original)));
+    assertThat(IoUtils.toStringUsingTlb(new StringReader(original)))
+        .isEqualTo(original);
   }
 
   @Test
   void shouldThrownUncheckedIOExceptionDuringConvertingReaderToStrungUsingTLB() {
-
-    Assertions.assertThrows(
-        UncheckedIOException.class, () -> IoUtils.toStringUsingTlb(new Reader() {
+    assertThatThrownBy(() -> IoUtils.toStringUsingTlb(new Reader() {
           @Override
           public int read(char[] cbuf, int off, int len) throws IOException {
             throw new IOException("test");
@@ -91,6 +86,7 @@ class IoUtilsTest {
 
           @Override
           public void close() {}
-        }));
+        }))
+        .isInstanceOf(UncheckedIOException.class);
   }
 }

--- a/rlib-logger-api/src/test/java/javasabr/rlib/logger/api/LoggerTest.java
+++ b/rlib-logger-api/src/test/java/javasabr/rlib/logger/api/LoggerTest.java
@@ -1,9 +1,10 @@
 package javasabr.rlib.logger.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.jspecify.annotations.NonNull;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,6 @@ public class LoggerTest {
   @Test
   @DisplayName("should print all debug methods")
   void shouldPrintAllDebugMethods() {
-
     // given:
     var messages = new ArrayList<String>();
     var expectedMessages = List.of(
@@ -59,14 +59,13 @@ public class LoggerTest {
     logger.debug("str11", "str12", "str13", "str14", "msg11[%s, %s, %s, %s]"::formatted);
 
     // then:
-    Assertions.assertEquals(11, messages.size());
-    Assertions.assertEquals(expectedMessages, messages);
+    assertThat(messages.size()).isEqualTo(11);
+    assertThat(messages).isEqualTo(expectedMessages);
   }
 
   @Test
   @DisplayName("should print all info methods")
   void shouldPrintAllInfoMethods() {
-
     // given:
     var messages = new ArrayList<String>();
     var expectedMessages = List.of(
@@ -113,14 +112,13 @@ public class LoggerTest {
     logger.info("str11", "str12", "str13", "str14", "msg11[%s, %s, %s, %s]"::formatted);
 
     // then:
-    Assertions.assertEquals(11, messages.size());
-    Assertions.assertEquals(expectedMessages, messages);
+    assertThat(messages.size()).isEqualTo(11);
+    assertThat(messages).isEqualTo(expectedMessages);
   }
 
   @Test
   @DisplayName("should print all warning methods")
   void shouldPrintAllWarningMethods() {
-
     // given:
     var messages = new ArrayList<String>();
     var expectedMessages = List.of(
@@ -167,14 +165,13 @@ public class LoggerTest {
     logger.warning("str11", "str12", "str13", "str14", "msg11[%s, %s, %s, %s]"::formatted);
 
     // then:
-    Assertions.assertEquals(11, messages.size());
-    Assertions.assertEquals(expectedMessages, messages);
+    assertThat(messages.size()).isEqualTo(11);
+    assertThat(messages).isEqualTo(expectedMessages);
   }
 
   @Test
   @DisplayName("should print all error methods")
   void shouldPrintAllErrorMethods() {
-
     // given:
     var messages = new ArrayList<String>();
     var expectedMessages = List.of(
@@ -221,7 +218,7 @@ public class LoggerTest {
     logger.error("str11", "str12", "str13", "str14", "msg11[%s, %s, %s, %s]"::formatted);
 
     // then:
-    Assertions.assertEquals(11, messages.size());
-    Assertions.assertEquals(expectedMessages, messages);
+    assertThat(messages.size()).isEqualTo(11);
+    assertThat(messages).isEqualTo(expectedMessages);
   }
 }

--- a/rlib-logger-impl/src/test/java/javasabr/rlib/logger/impl/DefaultLoggerTest.java
+++ b/rlib-logger-impl/src/test/java/javasabr/rlib/logger/impl/DefaultLoggerTest.java
@@ -1,12 +1,13 @@
 package javasabr.rlib.logger.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javasabr.rlib.collections.array.ArrayFactory;
 import javasabr.rlib.collections.array.LockableArray;
 import javasabr.rlib.logger.api.LoggerLevel;
 import javasabr.rlib.logger.api.LoggerListener;
 import javasabr.rlib.logger.api.LoggerManager;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,10 +48,9 @@ public class DefaultLoggerTest {
 
   @Test
   void shouldCreateDefaultLoggerImplementation() {
-
     var logger = LoggerManager.getLogger(DefaultLoggerTest.class);
-
-    Assertions.assertTrue(logger instanceof DefaultLogger);
+    assertThat(logger)
+        .isInstanceOf(DefaultLogger.class);
   }
 
   @Test
@@ -59,10 +59,10 @@ public class DefaultLoggerTest {
     var logger = LoggerManager.getLogger(DefaultLoggerTest.class);
     logger.print(LoggerLevel.ERROR, "test data");
 
-    Assertions.assertEquals(1, WROTE_DATA.size());
+    assertThat(WROTE_DATA.size()).isEqualTo(1);
 
     logger.print(LoggerLevel.ERROR, "test data 2");
 
-    Assertions.assertEquals(2, WROTE_DATA.size());
+    assertThat(WROTE_DATA.size()).isEqualTo(2);
   }
 }

--- a/rlib-logger-slf4j/src/test/java/javasabr/rlib/logger/slf4j/Slf4jLoggerTest.java
+++ b/rlib-logger-slf4j/src/test/java/javasabr/rlib/logger/slf4j/Slf4jLoggerTest.java
@@ -1,16 +1,15 @@
 package javasabr.rlib.logger.slf4j;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javasabr.rlib.logger.api.LoggerManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class Slf4jLoggerTest {
 
   @Test
   void shouldCreateDefaultLoggerImplementation() {
-
     var logger = LoggerManager.getLogger(Slf4jLoggerTest.class);
-
-    Assertions.assertTrue(logger instanceof Slf4jLogger);
+    assertThat(logger).isInstanceOf(Slf4jLogger.class);
   }
 }

--- a/rlib-mail/src/test/java/javasabr/rlib/mail/sender/JavaxMailSenderTest.java
+++ b/rlib-mail/src/test/java/javasabr/rlib/mail/sender/JavaxMailSenderTest.java
@@ -1,15 +1,15 @@
 package javasabr.rlib.mail.sender;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javasabr.rlib.mail.BaseMailTest;
 import javasabr.rlib.mail.sender.impl.JavaxMailSender;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class JavaxMailSenderTest extends BaseMailTest {
 
   @Test
   void shouldSendEmailSuccessfully() {
-
     var smtpServer = FAKE_SMTP_TEST_CONTAINER;
     var smtpPort = smtpServer.getSmtpPort();
     var smtpUser = smtpServer.getSmtpUser();
@@ -28,10 +28,12 @@ public class JavaxMailSenderTest extends BaseMailTest {
     var sender = new JavaxMailSender(config);
     sender.send("to@test.com", "Test Subject", "Content");
 
-    Assertions.assertEquals(1, smtpServer.getEmailCountFrom("from@test.com"));
+    assertThat(smtpServer.getEmailCountFrom("from@test.com"))
+        .isEqualTo(1);
 
     sender.send("to@test.com", "Test Subject 2", "Content 2");
 
-    Assertions.assertEquals(2, smtpServer.getEmailCountFrom("from@test.com"));
+    assertThat(smtpServer.getEmailCountFrom("from@test.com"))
+        .isEqualTo(2);
   }
 }

--- a/rlib-network/src/loadTest/java/javasabr/rlib/network/StringNetworkLoadTest.java
+++ b/rlib-network/src/loadTest/java/javasabr/rlib/network/StringNetworkLoadTest.java
@@ -1,5 +1,7 @@
 package javasabr.rlib.network;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -27,8 +29,6 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.experimental.Accessors;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @CustomLog
 public class StringNetworkLoadTest {

--- a/rlib-network/src/loadTest/java/javasabr/rlib/network/StringNetworkLoadTest.java
+++ b/rlib-network/src/loadTest/java/javasabr/rlib/network/StringNetworkLoadTest.java
@@ -26,8 +26,9 @@ import lombok.CustomLog;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.experimental.Accessors;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @CustomLog
 public class StringNetworkLoadTest {
@@ -164,9 +165,9 @@ public class StringNetworkLoadTest {
       testClient.connectAndSendMessages(serverAddress, messagesPerIteration);
     }
 
-    Assertions
-        .assertTrue(finalWaiter.await(300_000, TimeUnit.MILLISECONDS),
-            "Still not received [%s] -> [%s] messages".formatted(expectedMessages, finalWaiter.getCount()));
+    assertThat(finalWaiter.await(300_000, TimeUnit.MILLISECONDS))
+        .as("Still not received [%s] -> [%s] messages".formatted(expectedMessages, finalWaiter.getCount()))
+        .isTrue();
 
     for (TestClient client : clients) {
       client.close();

--- a/rlib-network/src/loadTest/java/javasabr/rlib/network/StringSslNetworkLoadTest.java
+++ b/rlib-network/src/loadTest/java/javasabr/rlib/network/StringSslNetworkLoadTest.java
@@ -29,8 +29,9 @@ import lombok.CustomLog;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.experimental.Accessors;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @CustomLog
 public class StringSslNetworkLoadTest {
@@ -176,9 +177,9 @@ public class StringSslNetworkLoadTest {
     ThreadUtils.sleep(30000);
     finalWaiter.countDown();
 
-    Assertions
-        .assertTrue(finalWaiter.await(300_000, TimeUnit.MILLISECONDS),
-            "Still not received [%s] -> [%s] messages".formatted(expectedMessages, finalWaiter.getCount()));
+    assertThat(finalWaiter.await(300_000, TimeUnit.MILLISECONDS))
+        .as("Still not received [%s] -> [%s] messages".formatted(expectedMessages, finalWaiter.getCount()))
+        .isTrue();
 
     for (TestClient client : clients) {
       client.close();

--- a/rlib-network/src/loadTest/java/javasabr/rlib/network/StringSslNetworkLoadTest.java
+++ b/rlib-network/src/loadTest/java/javasabr/rlib/network/StringSslNetworkLoadTest.java
@@ -1,5 +1,7 @@
 package javasabr.rlib.network;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -30,8 +32,6 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.experimental.Accessors;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @CustomLog
 public class StringSslNetworkLoadTest {

--- a/rlib-network/src/test/java/javasabr/rlib/network/DefaultNetworkTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/DefaultNetworkTest.java
@@ -1,6 +1,7 @@
 package javasabr.rlib.network;
 
 import static javasabr.rlib.network.ServerNetworkConfig.DEFAULT_SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -29,7 +30,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -210,9 +210,10 @@ public class DefaultNetworkTest extends BaseNetworkTest {
           counter.countDown();
         });
 
-    Assertions.assertTrue(
-        counter.await(10000, TimeUnit.MILLISECONDS),
-        "Still wait for " + counter.getCount() + " packets...");
+    
+    assertThat(counter.await(10000, TimeUnit.MILLISECONDS))
+        .as(() -> "Still wait for " + counter.getCount() + " packets...")
+        .isTrue();
 
     clientNetwork.shutdown();
     serverNetwork.shutdown();
@@ -275,7 +276,9 @@ public class DefaultNetworkTest extends BaseNetworkTest {
       List<? extends ReadableNetworkPacket<DefaultConnection>> receivedPackets =
           ObjectUtils.notNull(pendingPacketsOnServer.blockFirst(Duration.ofSeconds(5)));
 
-      Assertions.assertEquals(packetCount, receivedPackets.size(), "Didn't receive all packets");
+      assertThat(receivedPackets.size())
+          .as("Didn't receive all packets")
+          .isEqualTo(packetCount);
 
       var wrongPacket = receivedPackets
           .stream()
@@ -287,7 +290,9 @@ public class DefaultNetworkTest extends BaseNetworkTest {
           .findFirst()
           .orElse(null);
 
-      Assertions.assertNull(wrongPacket, () -> "Wrong received packet: " + wrongPacket);
+      assertThat(wrongPacket)
+          .as("Wrong received packet: " + wrongPacket)
+          .isNull();
     }
   }
 }

--- a/rlib-network/src/test/java/javasabr/rlib/network/HandlingValidAndInvalidReceivedPacketsTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/HandlingValidAndInvalidReceivedPacketsTest.java
@@ -20,7 +20,6 @@ import javasabr.rlib.network.packet.registry.ReadableNetworkPacketRegistry;
 import javasabr.rlib.network.server.ServerNetwork;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @CustomLog
@@ -113,9 +112,9 @@ public class HandlingValidAndInvalidReceivedPacketsTest extends BaseNetworkTest 
             }))
         .subscribe();
 
-    Assertions.assertTrue(
-        counter.await(10000, TimeUnit.MILLISECONDS),
-        "Still wait for " + counter.getCount() + " packets...");
+    assertThat(counter.await(10000, TimeUnit.MILLISECONDS))
+        .as("Still wait for " + counter.getCount() + " packets...")
+        .isTrue();
 
     clientNetwork.shutdown();
     serverNetwork.shutdown();

--- a/rlib-network/src/test/java/javasabr/rlib/network/IdBasedReadableNetworkPacketRegistryTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/IdBasedReadableNetworkPacketRegistryTest.java
@@ -1,5 +1,9 @@
 package javasabr.rlib.network;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import javasabr.rlib.collections.array.Array;
 import javasabr.rlib.common.util.ClassUtils;
 import javasabr.rlib.network.annotation.NetworkPacketDescription;
@@ -9,7 +13,6 @@ import javasabr.rlib.network.packet.impl.AbstractIdBasedReadableNetworkPacket;
 import javasabr.rlib.network.packet.impl.DefaultReadableNetworkPacket;
 import javasabr.rlib.network.packet.registry.impl.IdBasedReadableNetworkPacketRegistry;
 import lombok.NoArgsConstructor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -53,54 +56,62 @@ public class IdBasedReadableNetworkPacketRegistryTest {
 
   @Test
   void shouldBeCreated() {
-    Assertions.assertDoesNotThrow(
-        () -> new IdBasedReadableNetworkPacketRegistry<>(IdBasedReadableNetworkPacket.class));
+    assertThatCode(
+        () -> new IdBasedReadableNetworkPacketRegistry<>(IdBasedReadableNetworkPacket.class))
+        .doesNotThrowAnyException();
   }
 
   @Test
   void shouldRegister3PacketsByArray() {
-
     var registry = new IdBasedReadableNetworkPacketRegistry<>(IdBasedReadableNetworkPacket.class)
         .register(Array.typed(Class.class, Impl1.class, Impl2.class, Impl3.class));
 
-    Assertions.assertInstanceOf(Impl1.class, registry.resolvePrototypeById(1));
-    Assertions.assertInstanceOf(Impl2.class, registry.resolvePrototypeById(2));
-    Assertions.assertInstanceOf(Impl3.class, registry.resolvePrototypeById(3));
+    assertThat(registry.resolvePrototypeById(1))
+        .isInstanceOf(Impl1.class);
+    assertThat(registry.resolvePrototypeById(2))
+        .isInstanceOf(Impl2.class);
+    assertThat(registry.resolvePrototypeById(3))
+        .isInstanceOf(Impl3.class);
   }
 
   @Test
   void shouldRegister3PacketsByVarargs() {
-
     var registry = new IdBasedReadableNetworkPacketRegistry<>(IdBasedReadableNetworkPacket.class)
         .register(Impl1.class, Impl2.class, Impl3.class);
 
-    Assertions.assertInstanceOf(Impl1.class, registry.resolvePrototypeById(1));
-    Assertions.assertInstanceOf(Impl2.class, registry.resolvePrototypeById(2));
-    Assertions.assertInstanceOf(Impl3.class, registry.resolvePrototypeById(3));
+    assertThat(registry.resolvePrototypeById(1))
+        .isInstanceOf(Impl1.class);
+    assertThat(registry.resolvePrototypeById(2))
+        .isInstanceOf(Impl2.class);
+    assertThat(registry.resolvePrototypeById(3))
+        .isInstanceOf(Impl3.class);
   }
 
   @Test
   void shouldRegister3PacketsBySingle() {
-
     var registry = new IdBasedReadableNetworkPacketRegistry<>(IdBasedReadableNetworkPacket.class)
         .register(Impl1.class)
         .register(Impl2.class)
         .register(Impl3.class);
 
-    Assertions.assertInstanceOf(Impl1.class, registry.resolvePrototypeById(1));
-    Assertions.assertInstanceOf(Impl2.class, registry.resolvePrototypeById(2));
-    Assertions.assertInstanceOf(Impl3.class, registry.resolvePrototypeById(3));
+    assertThat(registry.resolvePrototypeById(1))
+        .isInstanceOf(Impl1.class);
+    assertThat(registry.resolvePrototypeById(2))
+        .isInstanceOf(Impl2.class);
+    assertThat(registry.resolvePrototypeById(3))
+        .isInstanceOf(Impl3.class);
   }
 
   @Test
   void shouldRegister2PrivatePacketsBySingle() {
-
     var registry = new IdBasedReadableNetworkPacketRegistry<>(PrivateBase.class)
         .register(PrivateImpl1.class, PrivateImpl1::new)
         .register(PrivateImpl2.class, PrivateImpl2::new);
 
-    Assertions.assertInstanceOf(PrivateImpl1.class, registry.resolvePrototypeById(1));
-    Assertions.assertInstanceOf(PrivateImpl2.class, registry.resolvePrototypeById(10));
+    assertThat(registry.resolvePrototypeById(1))
+        .isInstanceOf(PrivateImpl1.class);
+    assertThat(registry.resolvePrototypeById(10))
+        .isInstanceOf(PrivateImpl2.class);
   }
 
   @Test
@@ -116,8 +127,11 @@ public class IdBasedReadableNetworkPacketRegistryTest {
     var registry = new IdBasedReadableNetworkPacketRegistry<>(PublicBase.class)
         .register(ClassUtils.<Array<Class<? extends PublicBase>>>unsafeNNCast(array));
 
-    Assertions.assertInstanceOf(PublicImpl1.class, registry.resolvePrototypeById(1));
-    Assertions.assertThrows(IllegalArgumentException.class, () -> registry.resolvePrototypeById(2));
-    Assertions.assertInstanceOf(PublicImpl2.class, registry.resolvePrototypeById(5));
+    assertThat(registry.resolvePrototypeById(1))
+        .isInstanceOf(PublicImpl1.class);
+    assertThatThrownBy(() -> registry.resolvePrototypeById(2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThat(registry.resolvePrototypeById(5))
+        .isInstanceOf(PublicImpl2.class);
   }
 }

--- a/rlib-network/src/test/java/javasabr/rlib/network/NetworkPacketTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/NetworkPacketTest.java
@@ -1,5 +1,7 @@
 package javasabr.rlib.network;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import javasabr.rlib.network.BaseNetworkTest.MockConnection;
@@ -8,7 +10,6 @@ import javasabr.rlib.network.packet.impl.AbstractWritableNetworkPacket;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -132,7 +133,7 @@ class NetworkPacketTest {
 
     // then:
     byte[] wroteBytes = Arrays.copyOf(buffer.array(), buffer.limit());
-    Assertions.assertArrayEquals(expected, wroteBytes);
+    assertThat(wroteBytes).isEqualTo(expected);
   }
 
   @Test
@@ -170,9 +171,9 @@ class NetworkPacketTest {
     packet.read(BaseNetworkTest.MOCK_CONNECTION, ByteBuffer.wrap(data), data.length);
 
     // then:
-    Assertions.assertEquals(expected, packet);
-    Assertions.assertArrayEquals(expected.byteArrayField, packet.byteArrayField);
-    Assertions.assertArrayEquals(expected.bytesField1, packet.bytesField1);
-    Assertions.assertArrayEquals(expected.bytesField2, packet.bytesField2);
+    assertThat(packet).isEqualTo(expected);
+    assertThat(packet.byteArrayField).isEqualTo(expected.byteArrayField);
+    assertThat(packet.bytesField1).isEqualTo(expected.bytesField1);
+    assertThat(packet.bytesField2).isEqualTo(expected.bytesField2);
   }
 }

--- a/rlib-network/src/test/java/javasabr/rlib/network/StringNetworkTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/StringNetworkTest.java
@@ -1,6 +1,7 @@
 package javasabr.rlib.network;
 
 import static javasabr.rlib.network.ServerNetworkConfig.DEFAULT_SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -26,7 +27,6 @@ import javasabr.rlib.network.packet.impl.StringWritableNetworkPacket;
 import javasabr.rlib.network.server.ServerNetwork;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
@@ -81,9 +81,9 @@ public class StringNetworkTest extends BaseNetworkTest {
           log.info(counter.getCount(), "Still wait for:[%s]"::formatted);
         });
 
-    Assertions.assertTrue(
-        counter.await(10000, TimeUnit.MINUTES),
-        "Still wait for " + counter.getCount() + " packets...");
+    assertThat(counter.await(10000, TimeUnit.MINUTES))
+        .as(() -> "Still wait for " + counter.getCount() + " packets...")
+        .isTrue();
 
     clientNetwork.shutdown();
     serverNetwork.shutdown();
@@ -136,7 +136,9 @@ public class StringNetworkTest extends BaseNetworkTest {
 
       log.info(receivedPackets.size(), "Received [%s] packets from client"::formatted);
 
-      Assertions.assertEquals(packetCount, receivedPackets.size(), "Didn't receive all packets");
+      assertThat(receivedPackets.size())
+          .as("Didn't receive all packets")
+          .isEqualTo(packetCount);
 
       var wrongPacket = receivedPackets
           .stream()
@@ -146,7 +148,9 @@ public class StringNetworkTest extends BaseNetworkTest {
           .findFirst()
           .orElse(null);
 
-      Assertions.assertNull(wrongPacket, () -> "Wrong received packet: " + wrongPacket);
+      assertThat(wrongPacket)
+          .as("Wrong received packet: " + wrongPacket)
+          .isNull();
     }
   }
 
@@ -194,7 +198,9 @@ public class StringNetworkTest extends BaseNetworkTest {
 
       log.info(receivedPackets.size(), "Received [%s] packets from client"::formatted);
 
-      Assertions.assertEquals(packetCount, receivedPackets.size(), "Didn't receive all packets");
+      assertThat(receivedPackets.size())
+          .as("Didn't receive all packets")
+          .isEqualTo(packetCount);
 
       var wrongPacket = receivedPackets
           .stream()
@@ -204,7 +210,9 @@ public class StringNetworkTest extends BaseNetworkTest {
           .findFirst()
           .orElse(null);
 
-      Assertions.assertNull(wrongPacket, () -> "Wrong received packet: " + wrongPacket);
+      assertThat(wrongPacket)
+          .as("Wrong received packet: " + wrongPacket)
+          .isNull();
     }
   }
 
@@ -252,7 +260,9 @@ public class StringNetworkTest extends BaseNetworkTest {
 
       log.info(receivedPackets.size(), "Received [%s] packets from client"::formatted);
 
-      Assertions.assertEquals(packetCount, receivedPackets.size(), "Didn't receive all packets");
+      assertThat(receivedPackets.size())
+          .as("Didn't receive all packets")
+          .isEqualTo(packetCount);
 
       var wrongPacket = receivedPackets
           .stream()
@@ -262,7 +272,9 @@ public class StringNetworkTest extends BaseNetworkTest {
           .findFirst()
           .orElse(null);
 
-      Assertions.assertNull(wrongPacket, () -> "Wrong received packet: " + wrongPacket);
+      assertThat(wrongPacket)
+          .as("Wrong received packet: " + wrongPacket)
+          .isNull();
     }
   }
 
@@ -319,12 +331,12 @@ public class StringNetworkTest extends BaseNetworkTest {
           receivedPacketsOnClients.incrementAndGet();
           counter.countDown();
         });
-
-    Assertions.assertTrue(
-        counter.await(10000, TimeUnit.MILLISECONDS),
-        "Still wait for " + counter.getCount() + " packets... " + "Sent packets to server: " + sentPacketsToServer
+    
+    assertThat(counter.await(10000, TimeUnit.MILLISECONDS))
+        .as(() -> "Still wait for " + counter.getCount() + " packets... " + "Sent packets to server: " + sentPacketsToServer
             + ", " + "Received packets on server: " + receivedPacketsOnServer + ", " + "Received packets on clients: "
-            + receivedPacketsOnClients);
+            + receivedPacketsOnClients)
+        .isTrue();
 
     serverNetwork.shutdown();
   }
@@ -380,11 +392,11 @@ public class StringNetworkTest extends BaseNetworkTest {
             .peek(value -> connection.sendInBackground(newMessage(minMessageLength, maxMessageLength)))
             .forEach(val -> sentPacketsToServer.incrementAndGet()));
 
-    Assertions.assertTrue(
-        counter.await(5, TimeUnit.SECONDS),
-        "Still wait for " + counter.getCount() + " packets... " + "Sent packets to server: " + sentPacketsToServer
+    assertThat(counter.await(5, TimeUnit.SECONDS))
+        .as("Still wait for " + counter.getCount() + " packets... " + "Sent packets to server: " + sentPacketsToServer
             + ", " + "Received packets on server: " + receivedPacketsOnServer + ", " + "Received packets on clients: "
-            + receivedPacketsOnClients);
+            + receivedPacketsOnClients)
+        .isTrue();
 
     clients.forEach(Network::shutdown);
     serverNetwork.shutdown();
@@ -423,12 +435,16 @@ public class StringNetworkTest extends BaseNetworkTest {
           .findFirst()
           .orElse(null);
 
-      Assertions.assertNull(notSentPacket, "Found not sent packets...");
+      assertThat(notSentPacket)
+          .as("Found not sent packets...")
+          .isNull();
 
       // so all packets are already sent, we should not wait for long time to get result
       var receivedPackets = ObjectUtils.notNull(pendingPacketsOnServer.blockFirst(Duration.ofMillis(100)));
 
-      Assertions.assertEquals(packetCount, receivedPackets.size(), "Didn't receive all packets");
+      assertThat(receivedPackets.size())
+          .as("Didn't receive all packets")
+          .isEqualTo(packetCount);
     }
   }
 

--- a/rlib-network/src/test/java/javasabr/rlib/network/StringSslNetworkTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/StringSslNetworkTest.java
@@ -1,5 +1,7 @@
 package javasabr.rlib.network;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -33,7 +35,6 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -71,7 +72,7 @@ public class StringSslNetworkTest extends BaseNetworkTest {
     Scanner serverIn = new Scanner(clientSocketOnServer.getInputStream());
     String receivedOnServer = serverIn.next() + " " + serverIn.next();
 
-    Assertions.assertEquals("Hello SSL", receivedOnServer);
+    assertThat(receivedOnServer).isEqualTo("Hello SSL");
   }
 
   @Test
@@ -179,7 +180,7 @@ public class StringSslNetworkTest extends BaseNetworkTest {
     var receivedPacket = new StringReadableNetworkPacket<StringDataSslConnection>();
     receivedPacket.read(null, buffer, dataLength);
 
-    Assertions.assertEquals("Hello SSL", receivedPacket.data());
+    assertThat(receivedPacket.data()).isEqualTo("Hello SSL");
 
     log.info(receivedPacket.data(), "Received from client:[%s]"::formatted);
 
@@ -196,9 +197,9 @@ public class StringSslNetworkTest extends BaseNetworkTest {
 
     buffer.clear();
 
-    Assertions.assertTrue(
-        counter.await(100_000, TimeUnit.MILLISECONDS),
-        "Still wait for " + counter.getCount() + " packets...");
+    assertThat(counter.await(100_000, TimeUnit.MILLISECONDS))
+        .as("Still wait for " + counter.getCount() + " packets...")
+        .isTrue();
 
     clientNetwork.shutdown();
     serverSocket.close();
@@ -262,9 +263,9 @@ public class StringSslNetworkTest extends BaseNetworkTest {
           counter.countDown();
         });
 
-    Assertions.assertTrue(
-        counter.await(60, TimeUnit.SECONDS),
-        "Still wait for " + counter.getCount() + " packets...");
+    assertThat(counter.await(60, TimeUnit.SECONDS))
+        .as(() -> "Still wait for " + counter.getCount() + " packets...")
+        .isTrue();
 
     serverNetwork.shutdown();
     clientNetwork.shutdown();
@@ -309,7 +310,9 @@ public class StringSslNetworkTest extends BaseNetworkTest {
       List<? extends ReadableNetworkPacket<StringDataSslConnection>> receivedPackets =
           ObjectUtils.notNull(pendingPacketsOnServer.blockFirst(Duration.ofSeconds(5000)));
 
-      Assertions.assertEquals(packetCount, receivedPackets.size(), "Didn't receive all packets");
+      assertThat(receivedPackets.size())
+          .as("Didn't receive all packets")
+          .isEqualTo(packetCount);
 
       var wrongPacket = receivedPackets
           .stream()
@@ -319,7 +322,9 @@ public class StringSslNetworkTest extends BaseNetworkTest {
           .findFirst()
           .orElse(null);
 
-      Assertions.assertNull(wrongPacket, () -> "Wrong received packet: " + wrongPacket);
+      assertThat(wrongPacket)
+          .as("Wrong received packet: " + wrongPacket)
+          .isNull();
     }
   }
 

--- a/rlib-network/src/test/java/javasabr/rlib/network/impl/DefaultDataConnectionTest.java
+++ b/rlib-network/src/test/java/javasabr/rlib/network/impl/DefaultDataConnectionTest.java
@@ -1,5 +1,7 @@
 package javasabr.rlib.network.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.CompletionHandler;
@@ -11,7 +13,6 @@ import javasabr.rlib.network.ServerNetworkConfig.SimpleServerNetworkConfig;
 import javasabr.rlib.network.packet.ReadableNetworkPacket;
 import javasabr.rlib.network.packet.impl.DefaultNetworkPacketReader;
 import org.jspecify.annotations.NonNull;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,12 +78,12 @@ class DefaultDataConnectionTest {
         .read(Mockito.any(), Mockito.any(), Mockito.any());
 
     // then:
-    Assertions.assertFalse(connection.closed());
+    assertThat(connection.closed()).isFalse();
 
     // when:
     packetReader.startRead();
 
     // then:
-    Assertions.assertTrue(connection.closed());
+    assertThat(connection.closed()).isTrue();
   }
 }

--- a/rlib-plugin-system/src/test/java/javasabr/rlib/plugin/system/extension/ExtensionPointTests.java
+++ b/rlib-plugin-system/src/test/java/javasabr/rlib/plugin/system/extension/ExtensionPointTests.java
@@ -1,7 +1,8 @@
 package javasabr.rlib.plugin.system.extension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -11,17 +12,16 @@ public class ExtensionPointTests {
 
   @Test
   void registerExtensionTest() {
-
     var point = new ExtensionPoint<String>();
     point.register("a", "b");
     point.register("c");
 
-    Assertions.assertIterableEquals(Arrays.asList("a", "b", "c"), point.extensions());
+    assertThat(point.extensions())
+        .isEqualTo(Arrays.asList("a", "b", "c"));
   }
 
   @Test
   void registerExtensionPointTest() {
-
     var manager = new ExtensionPointManager();
     manager.addExtension("Test1", 5);
     manager.addExtension("Test1", 6, 7);
@@ -33,7 +33,9 @@ public class ExtensionPointTests {
     var forTest1 = manager.<Integer>getOrCreateExtensionPoint("Test1");
     var forTest2 = manager.<Integer>getOrCreateExtensionPoint("Test2");
 
-    Assertions.assertIterableEquals(Arrays.asList(5, 6, 7), forTest1.extensions());
-    Assertions.assertIterableEquals(Arrays.asList(1, 2, 3), forTest2.extensions());
+    assertThat(forTest1.extensions())
+        .isEqualTo(Arrays.asList(5, 6, 7));
+    assertThat(forTest2.extensions())
+        .isEqualTo(Arrays.asList(1, 2, 3));
   }
 }

--- a/rlib-reference/src/test/java/javasabr/rlib/reference/ReferencesTest.java
+++ b/rlib-reference/src/test/java/javasabr/rlib/reference/ReferencesTest.java
@@ -1,6 +1,7 @@
 package javasabr.rlib.reference;
 
-import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -20,14 +21,14 @@ public class ReferencesTest {
     var objRef = ReferenceFactory.objRef("Val");
     var shortRef = ReferenceFactory.newShortRef((short) 7);
 
-    Assertions.assertEquals(5, byteRef.value());
-    Assertions.assertEquals('T', charRef.value());
-    Assertions.assertEquals(1.5D, doubleRef.value());
-    Assertions.assertEquals(2.5F, floatRef.value());
-    Assertions.assertEquals(5, intRef.value());
-    Assertions.assertEquals(7L, longRef.value());
-    Assertions.assertEquals("Val", objRef.value());
-    Assertions.assertEquals(7, shortRef.value());
+    assertThat(byteRef.value()).isEqualTo((byte) 5);
+    assertThat(charRef.value()).isEqualTo('T');
+    assertThat(doubleRef.value()).isEqualTo(1.5D);
+    assertThat(floatRef.value()).isEqualTo(2.5F);
+    assertThat(intRef.value()).isEqualTo(5);
+    assertThat(longRef.value()).isEqualTo(7L);
+    assertThat(objRef.value()).isEqualTo("Val");
+    assertThat(shortRef.value()).isEqualTo((short) 7);
   }
 
   @Test
@@ -42,14 +43,14 @@ public class ReferencesTest {
     var objRef = ReferenceFactory.threadLocalObjRef("Val3");
     var shortRef = ReferenceFactory.threadLocalShortRef((short) 2);
 
-    Assertions.assertEquals(3, byteRef.value());
-    Assertions.assertEquals('d', charRef.value());
-    Assertions.assertEquals(3.5D, doubleRef.value());
-    Assertions.assertEquals(1.5F, floatRef.value());
-    Assertions.assertEquals(7, intRef.value());
-    Assertions.assertEquals(4L, longRef.value());
-    Assertions.assertEquals("Val3", objRef.value());
-    Assertions.assertEquals(2, shortRef.value());
+    assertThat(byteRef.value()).isEqualTo((byte) 3);
+    assertThat(charRef.value()).isEqualTo('d');
+    assertThat(doubleRef.value()).isEqualTo(3.5D);
+    assertThat(floatRef.value()).isEqualTo(1.5F);
+    assertThat(intRef.value()).isEqualTo(7);
+    assertThat(longRef.value()).isEqualTo(4L);
+    assertThat(objRef.value()).isEqualTo("Val3");
+    assertThat(shortRef.value()).isEqualTo((short) 2);
 
     byteRef.release();
     charRef.release();
@@ -69,14 +70,14 @@ public class ReferencesTest {
     var objRef2 = ReferenceFactory.threadLocalObjRef("Val3");
     var shortRef2 = ReferenceFactory.threadLocalShortRef((short) 2);
 
-    Assertions.assertSame(byteRef, byteRef2);
-    Assertions.assertSame(charRef, charRef2);
-    Assertions.assertSame(doubleRef, doubleRef2);
-    Assertions.assertSame(floatRef, floatRef2);
-    Assertions.assertSame(intRef, intRef2);
-    Assertions.assertSame(longRef, longRef2);
-    Assertions.assertSame(objRef, objRef2);
-    Assertions.assertSame(shortRef, shortRef2);
+    assertThat(byteRef2).isSameAs(byteRef);
+    assertThat(charRef2).isSameAs(charRef);
+    assertThat(doubleRef2).isSameAs(doubleRef);
+    assertThat(floatRef2).isSameAs(floatRef);
+    assertThat(intRef2).isSameAs(intRef);
+    assertThat(longRef2).isSameAs(longRef);
+    assertThat(objRef2).isSameAs(objRef);
+    assertThat(shortRef2).isSameAs(shortRef);
 
     var byteRef3 = ReferenceFactory.threadLocalByteRef((byte) 3);
     var charRef3 = ReferenceFactory.threadLocalCharRef('d');
@@ -87,13 +88,13 @@ public class ReferencesTest {
     var objRef3 = ReferenceFactory.threadLocalObjRef("Val3");
     var shortRef3 = ReferenceFactory.threadLocalShortRef((short) 2);
 
-    Assertions.assertNotSame(byteRef, byteRef3);
-    Assertions.assertNotSame(charRef, charRef3);
-    Assertions.assertNotSame(doubleRef, doubleRef3);
-    Assertions.assertNotSame(floatRef, floatRef3);
-    Assertions.assertNotSame(intRef, intRef3);
-    Assertions.assertNotSame(longRef, longRef3);
-    Assertions.assertNotSame(objRef, objRef3);
-    Assertions.assertNotSame(shortRef, shortRef3);
+    assertThat(byteRef3).isNotSameAs(byteRef);
+    assertThat(charRef3).isNotSameAs(charRef);
+    assertThat(doubleRef3).isNotSameAs(doubleRef);
+    assertThat(floatRef3).isNotSameAs(floatRef);
+    assertThat(intRef3).isNotSameAs(intRef);
+    assertThat(longRef3).isNotSameAs(longRef);
+    assertThat(objRef3).isNotSameAs(objRef);
+    assertThat(shortRef3).isNotSameAs(shortRef);
   }
 }

--- a/rlib-testcontainers/src/test/java/javasabr/rlib/testcontainers/FakeSMTPTestContainerTest.java
+++ b/rlib-testcontainers/src/test/java/javasabr/rlib/testcontainers/FakeSMTPTestContainerTest.java
@@ -1,9 +1,10 @@
 package javasabr.rlib.testcontainers;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javasabr.rlib.mail.sender.MailSenderConfig;
 import javasabr.rlib.mail.sender.impl.JavaxMailSender;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -24,8 +25,8 @@ public class FakeSMTPTestContainerTest {
 
   @Test
   void shouldStartTestContainerAndCheckApi() {
-
-    Assertions.assertEquals(0, FAKE_SMTP_TEST_CONTAINER.getEmailCountFrom("from@test.com"));
+    assertThat(FAKE_SMTP_TEST_CONTAINER.getEmailCountFrom("from@test.com"))
+        .isEqualTo(0);
 
     var smtpServer = FAKE_SMTP_TEST_CONTAINER;
     var smtpPort = smtpServer.getSmtpPort();
@@ -45,10 +46,12 @@ public class FakeSMTPTestContainerTest {
     var sender = new JavaxMailSender(config);
     sender.send("to@test.com", "Test Subject", "Content");
 
-    Assertions.assertEquals(1, FAKE_SMTP_TEST_CONTAINER.getEmailCountFrom("from@test.com"));
+    assertThat(FAKE_SMTP_TEST_CONTAINER.getEmailCountFrom("from@test.com"))
+        .isEqualTo(1);
 
     FAKE_SMTP_TEST_CONTAINER.deleteEmails();
 
-    Assertions.assertEquals(0, FAKE_SMTP_TEST_CONTAINER.getEmailCountFrom("from@test.com"));
+    assertThat(FAKE_SMTP_TEST_CONTAINER.getEmailCountFrom("from@test.com"))
+        .isEqualTo(0);
   }
 }


### PR DESCRIPTION
## Pull request overview

This pull request extends the API for version 10 by migrating test assertions from JUnit to AssertJ and adding new dictionary methods (putIfAbsent and conditional remove).

**Changes:**
- Migrated all test assertions from `org.junit.jupiter.api.Assertions` to AssertJ's fluent API across 40+ test files
- Added `putIfAbsent(key, value)` method to MutableRefToRefDictionary, MutableLongToRefDictionary, and MutableIntToRefDictionary interfaces and implementations
- Added `remove(key, expectedValue)` method to the same dictionary interfaces and implementations for conditional removal
- Bumped version from 10.0.alpha10 to 10.0.alpha11