### PR TITLE
fix: Fix the edge case in collection values from Dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ repositories {
 }
 
 ext {
-    rlibVersion = "10.0.alpha15"
+    rlibVersion = "10.0.alpha16"
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-rootProject.version = "10.0.alpha15"
+rootProject.version = "10.0.alpha16"
 group = 'javasabr.rlib'
 
 allprojects {

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/array/impl/AbstractMutableArray.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/array/impl/AbstractMutableArray.java
@@ -208,8 +208,7 @@ public abstract class AbstractMutableArray<E> extends AbstractArray<E> implement
     }
     return this;
   }
-
-
+  
   @Override
   public UnsafeMutableArray<E> trimToSize() {
     @Nullable E[] wrapped = wrapped();

--- a/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/util/LinkedEntryUtils.java
+++ b/rlib-collections/src/main/java/javasabr/rlib/collections/dictionary/impl/util/LinkedEntryUtils.java
@@ -59,8 +59,10 @@ public class LinkedEntryUtils {
     if (size < 1) {
       return -1;
     }
+    int extra = 10; // if we have several values per one dictionary cell
+    int reserved = Math.min(limit, size) + extra;
     UnsafeMutableArray<V> unsafe = container.asUnsafe();
-    unsafe.prepareForSize(container.size() + Math.min(limit, size));
+    unsafe.prepareForSize(container.size() + reserved);
     for (int i = startIndex, length = entries.length; i < length; i++) {
       if (unsafe.size() >= limit) {
         return i;
@@ -69,7 +71,12 @@ public class LinkedEntryUtils {
       while (entry != null) {
         V value = entry.value();
         if (value != null) {
+          if (reserved < 1) {
+            unsafe.prepareForSize(container.size() + extra);
+            reserved = extra;
+          }
           unsafe.unsafeAdd(value);
+          reserved--;
         }
         entry = entry.next();
       }

--- a/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionaryTest.java
+++ b/rlib-collections/src/test/java/javasabr/rlib/collections/dictionary/MutableRefToRefDictionaryTest.java
@@ -213,7 +213,7 @@ class MutableRefToRefDictionaryTest {
   void shouldIterateAllValuesUsingPartIndex(MutableRefToRefDictionary<String, String> dictionary) {
     // given:
     var expectedValues = ArrayFactory.mutableArray(String.class);
-    for (int i = 10; i < 1000; i += 8) {
+    for (int i = 10; i < 1000; i++) {
       var value = "value_" + i;
       var key = "key_" + i;
       expectedValues.add(value);

--- a/rlib-logger-api/src/main/java/javasabr/rlib/logger/api/LoggerLevel.java
+++ b/rlib-logger-api/src/main/java/javasabr/rlib/logger/api/LoggerLevel.java
@@ -16,10 +16,10 @@ import lombok.experimental.FieldDefaults;
 @Accessors(fluent = true)
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public enum LoggerLevel {
-  INFO("INFO", "   ", true, true),
-  DEBUG("DEBUG", "  ", false, false),
-  WARNING("WARN", "", true, true),
-  ERROR("ERROR", "  ", true, true);
+  INFO("INFO", "  ", true, true),
+  DEBUG("DEBUG", " ", false, false),
+  WARNING("WARN", "  ", true, true),
+  ERROR("ERROR", " ", true, true);
 
   /**
    * The number of log levels.

--- a/rlib-logger-impl/src/test/java/javasabr/rlib/logger/impl/DefaultLoggerTest.java
+++ b/rlib-logger-impl/src/test/java/javasabr/rlib/logger/impl/DefaultLoggerTest.java
@@ -2,67 +2,87 @@ package javasabr.rlib.logger.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collection;
 import javasabr.rlib.collections.array.ArrayFactory;
 import javasabr.rlib.collections.array.LockableArray;
+import javasabr.rlib.collections.operation.LockableOperations;
 import javasabr.rlib.logger.api.LoggerLevel;
 import javasabr.rlib.logger.api.LoggerListener;
 import javasabr.rlib.logger.api.LoggerManager;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ResourceLock("LoggerListeners")
 public class DefaultLoggerTest {
 
-  private static final LockableArray<String> WROTE_DATA = ArrayFactory
+  private static final LockableArray<String> LOGS_DATA = ArrayFactory
       .stampedLockBasedArray(String.class);
-
-  private static final LoggerListener LOGGER_LISTENER = text -> {
-    long stamp = WROTE_DATA.writeLock();
-    try {
-      WROTE_DATA.add(text);
-    } finally {
-      WROTE_DATA.writeUnlock(stamp);
-    }
-  };
-
-  @BeforeAll
-  static void registerListener() {
-    LoggerManager.addListener(LOGGER_LISTENER);
-  }
-
-  @AfterAll
-  static void unregisterListener() {
-    LoggerManager.addListener(LOGGER_LISTENER);
-  }
+  public static final LockableOperations<LockableArray<String>> LOGS_DATA_OPERATIONS = 
+      LOGS_DATA.operations();
+  
+  private static final LoggerListener LOGGER_LISTENER = text -> LOGS_DATA_OPERATIONS
+      .inWriteLock(text, Collection::add);
 
   @BeforeEach
-  void clearWroteData() {
-    long stamp = WROTE_DATA.writeLock();
-    try {
-      WROTE_DATA.clear();
-    } finally {
-      WROTE_DATA.writeUnlock(stamp);
-    }
+  void prepare() {
+    LoggerManager.addListener(LOGGER_LISTENER);
+    LOGS_DATA_OPERATIONS
+        .inWriteLock(Collection::clear);
+  }
+  
+  @AfterEach
+  void cleanup() {
+    LOGS_DATA_OPERATIONS.inWriteLock(Collection::clear);
+    LoggerManager.removeListener(LOGGER_LISTENER);
   }
 
   @Test
   void shouldCreateDefaultLoggerImplementation() {
-    var logger = LoggerManager.getLogger(DefaultLoggerTest.class);
-    assertThat(logger)
+    assertThat(LoggerManager.getLogger(DefaultLoggerTest.class))
         .isInstanceOf(DefaultLogger.class);
   }
 
   @Test
   void shouldWriteDataToDefaultLoggerImplementation() {
-
+    // given:
     var logger = LoggerManager.getLogger(DefaultLoggerTest.class);
-    logger.print(LoggerLevel.ERROR, "test data");
+    logger.overrideEnabled(LoggerLevel.DEBUG, true);
+    logger.overrideEnabled(LoggerLevel.WARNING, true);
+    logger.overrideEnabled(LoggerLevel.ERROR, true);
+    logger.overrideEnabled(LoggerLevel.INFO, true);
+    
+    // when:
+    logger.print(LoggerLevel.ERROR, "test error data");
 
-    assertThat(WROTE_DATA.size()).isEqualTo(1);
+    // then:
+    assertThat(LOGS_DATA.size()).isEqualTo(1);
+    assertThat(LOGS_DATA.get(0)).startsWith("ERROR  ");
+    assertThat(LOGS_DATA.get(0)).endsWith("DefaultLoggerTest: test error data");
 
-    logger.print(LoggerLevel.ERROR, "test data 2");
+    // when:
+    logger.print(LoggerLevel.WARNING, "test warn data 2");
 
-    assertThat(WROTE_DATA.size()).isEqualTo(2);
+    // then:
+    assertThat(LOGS_DATA.size()).isEqualTo(2);
+    assertThat(LOGS_DATA.get(1)).startsWith("WARN   ");
+    assertThat(LOGS_DATA.get(1)).endsWith("DefaultLoggerTest: test warn data 2");
+
+    // when:
+    logger.print(LoggerLevel.DEBUG, "test debug data 3");
+
+    // then:
+    assertThat(LOGS_DATA.size()).isEqualTo(3);
+    assertThat(LOGS_DATA.get(2)).startsWith("DEBUG  ");
+    assertThat(LOGS_DATA.get(2)).endsWith("DefaultLoggerTest: test debug data 3");
+
+    // when:
+    logger.print(LoggerLevel.INFO, "test info data 4");
+
+    // then:
+    assertThat(LOGS_DATA.size()).isEqualTo(4);
+    assertThat(LOGS_DATA.get(3)).startsWith("INFO   ");
+    assertThat(LOGS_DATA.get(3)).endsWith("DefaultLoggerTest: test info data 4");
   }
 }

--- a/rlib-logger-impl/src/test/java/javasabr/rlib/logger/impl/DefaultLoggerTest.java
+++ b/rlib-logger-impl/src/test/java/javasabr/rlib/logger/impl/DefaultLoggerTest.java
@@ -15,11 +15,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 @ResourceLock("LoggerListeners")
-public class DefaultLoggerTest {
+class DefaultLoggerTest {
 
   private static final LockableArray<String> LOGS_DATA = ArrayFactory
       .stampedLockBasedArray(String.class);
-  public static final LockableOperations<LockableArray<String>> LOGS_DATA_OPERATIONS = 
+  private static final LockableOperations<LockableArray<String>> LOGS_DATA_OPERATIONS = 
       LOGS_DATA.operations();
   
   private static final LoggerListener LOGGER_LISTENER = text -> LOGS_DATA_OPERATIONS


### PR DESCRIPTION
## Pull request overview

This PR primarily addresses a dictionary values extraction edge case in the collections module, while also updating logger level padding/tests and bumping the project version.

**Changes:**
- Adjusted `LinkedEntryUtils.values(...)` capacity reservation for partial value extraction.
- Expanded `MutableRefToRefDictionaryTest` coverage for denser dictionary values iteration.
- Updated logger level formatting expectations and bumped version references to `10.0.alpha16`.
